### PR TITLE
Add prehandlers to swagger

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ const swaggerBaseProperties = {
   ],
   paths: {},
   securityDefinitions: {},
-  definitions: {}
+  definitions: {},
+  preHandlers: [checkValidToken, requireAdmin] // Add these to require auth
 }
 
 const routerInstance = router(server, {
@@ -156,6 +157,7 @@ NOTE: Only a limited amount of http error codes have been mapped so far, if the 
 
 Use `serveSwagger` to define the endpoint you wish to serve your docs at
 This will serve a swagger ui html page, with the swagger definition that is generated from your routes
+You can optionally pass middleware via the swagger config `preHandlers` e.g. to secure access to swagger
 
 If you want the raw swagger json definition you can use `toSwagger`
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ const swaggerBaseProperties = {
   paths: {},
   securityDefinitions: {},
   definitions: {},
-  preHandlers: [checkValidToken, requireAdmin] // Add these to require auth
+  preHandlers: [checkValidToken, requireAdmin] // pre handlers are run before your handlers, for example: you could use this to add authentication
 }
 
 const routerInstance = router(server, {

--- a/index.d.ts
+++ b/index.d.ts
@@ -39,6 +39,7 @@ declare module "@luxuryescapes/router" {
       paths: object;
       securityDefinitions: object;
       definitions: object;
+      preHandlers?: Handler[];
     };
   }
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -87,7 +87,7 @@ module.exports = exports = (app, opts = { }) => {
       if (preHandlers && preHandlers.length) {
         preHandlers.forEach(handler => app.use(path, asyncMiddleware(handler)))
       }
-      
+
       app.use(path, swaggerUi.serve, swaggerUi.setup(generateSwagger(routeDefinitions, opts.swaggerBaseProperties)))
     }
   }

--- a/lib/router.js
+++ b/lib/router.js
@@ -83,6 +83,11 @@ module.exports = exports = (app, opts = { }) => {
       return generateSwagger(routeDefinitions, opts.swaggerBaseProperties)
     },
     serveSwagger: (path) => {
+      const { preHandlers } = opts.swaggerBaseProperties
+      if (preHandlers && preHandlers.length) {
+        preHandlers.forEach(handler => app.use(path, asyncMiddleware(handler)))
+      }
+      
       app.use(path, swaggerUi.serve, swaggerUi.setup(generateSwagger(routeDefinitions, opts.swaggerBaseProperties)))
     }
   }


### PR DESCRIPTION
To aid collaboration I would like ability to expose swagger on deployed sites - but behind auth and only for admin accounts.

Clients could then pass auth middleware in the swagger opts e.g. routes.js:

```
const { router } = require('@luxuryescapes/router')
const checkValidToken = require('./middleware/check-valid-token')
const requireAdmin = require('./middleware/requires-admin')

exports.mount = app => {
  ...

  const routerAbstraction = router(app, {
    validateResponses: config.get().validateResponses,
    swaggerBaseProperties: {
      swagger: '2.0',
      ...
      preHandlers: [checkValidToken, requireAdmin] 
    }
  })

 ...

  routerAbstraction.serveSwagger('/api/docs/<service-name>')

  return routerAbstraction
}
