### PR TITLE
fix(types): extend Error for HTTPError class

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -86,7 +86,7 @@ declare module "@luxuryescapes/router" {
 
   export function router(app: Express, config: RouterConfig): RouterAbstraction;
 
-  interface HTTPError {
+  interface HTTPError extends Error {
     new (code: number, message: string, errors?: (string | object)[]) : HTTPError
     code: number
     errors: (string | object)[]


### PR DESCRIPTION
Without this we can get an eslint error when trying to throw

![image](https://user-images.githubusercontent.com/5554109/113966516-8c271f80-9872-11eb-8b92-5ef4fbbc609c.png)
