### PR TITLE
Use express' Handler type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,11 +1,11 @@
 declare module "@luxuryescapes/router" {
-  import { Request, Response, Express } from "express";
+  import { Request, Response, Express, NextFunction, Handler } from "express";
 
   export function errorHandler(
     err: Error,
     req: Request,
     res: Response,
-    next: Function
+    next: NextFunction
   ): void;
 
   interface Logger {
@@ -42,8 +42,6 @@ declare module "@luxuryescapes/router" {
       preHandlers?: Handler[];
     };
   }
-
-  type Handler = (req: Request, res: Response, next?: Function) => Promise<void>;
 
   interface RouteSchema {
     request?: {


### PR DESCRIPTION
Because `next` is not actually optional, and it has it's own definition that isn't just `Function`.