### PR TITLE
OpenAPI Schemas should have operationIDs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,13 +8,13 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "package-lock.json" }}
+            - v1-dependencies-{{ checksum "yarn.lock" }}
             - v1-dependencies-
 
       - run: npm install
 
       - save_cache:
-          key: v1-dependencies-{{ checksum "package-lock.json" }}
+          key: v1-dependencies-{{ checksum "yarn.lock" }}
           paths:
             - ./node_modules
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 declare module "@luxuryescapes/router" {
-  import { Request, Response, Express, NextFunction, Handler } from "express";
+  import { Request, Response, Express, NextFunction, Handler, RequestHandler } from "express";
 
   export function errorHandler(
     err: Error,
@@ -56,10 +56,11 @@ declare module "@luxuryescapes/router" {
 
   interface RouteOptions {
     url: string;
+    operationId?: string;
     schema?: RouteSchema;
     isPublic?: boolean;
     preHandlers?: Handler[];
-    handlers: Handler[];
+    handlers: RequestHandler<any, any, any, any>[];
     tags?: string[];
     summary?: string;
     description?: string;
@@ -71,6 +72,8 @@ declare module "@luxuryescapes/router" {
     schema: object;
   }
 
+  type OpenAPISpec = Record<string, any>;
+
   export interface RouterAbstraction {
     serveSwagger: (path: string) => void;
     app: Express,
@@ -80,6 +83,7 @@ declare module "@luxuryescapes/router" {
     delete: (options: RouteOptions) => void;
     patch: (options: RouteOptions) => void;
     schema: (options: SchemaRouteOptions) => void;
+    toSwagger: () => OpenAPISpec;
   }
 
   export function router(app: Express, config: RouterConfig): RouterAbstraction;

--- a/lib/generate-swagger.js
+++ b/lib/generate-swagger.js
@@ -155,6 +155,7 @@ const generateRoutes = (routeDefinitions, existingTags) => {
         paths[swaggerPath] = {}
       }
       paths[swaggerPath][method] = {
+        operationId: route.operationId || `${swaggerPath}/${method}`,
         tags: route.tags || [],
         summary: route.summary || '',
         description: route.description || '',

--- a/lib/router.js
+++ b/lib/router.js
@@ -11,7 +11,7 @@ const handle = (
   method,
   routeDefinitions,
   { validateResponses, logRequests, correlationIdExtractor, logger },
-  { url, preHandlers, handlers, schema, isPublic, tags, summary, description, warnOnRequestValidationError }
+  { url, operationId, preHandlers, handlers, schema, isPublic, tags, summary, description, warnOnRequestValidationError }
 ) => {
   let _handlers = []
 
@@ -19,7 +19,7 @@ const handle = (
     throw new Error(`Route already defined: (${method}) ${url}`)
   }
 
-  routeDefinitions[method][url] = { url, schema, isPublic, tags, summary, description }
+  routeDefinitions[method][url] = { url, operationId, schema, isPublic, tags, summary, description }
 
   if (logRequests) {
     _handlers.push(requestLogger({ correlationIdExtractor, logger }))

--- a/test/integration/router.test.js
+++ b/test/integration/router.test.js
@@ -287,19 +287,19 @@ describe('router', () => {
     })
 
     describe('when an operationId is given', () => {
-      beforeEach(() => setupRoutes({ routeOpts: { operationId: "updateSomething" } }));
+      beforeEach(() => setupRoutes({ routeOpts: { operationId: 'updateSomething' } }))
 
       it('sets the operationId', () => {
-        expect(routerInstance.toSwagger().paths["/api/something/{id}"]["put"]["operationId"]).to.eql("updateSomething")
-      });
+        expect(routerInstance.toSwagger().paths['/api/something/{id}']['put']['operationId']).to.eql('updateSomething')
+      })
     })
 
     describe('when an operationId is not given', () => {
-      beforeEach(() => setupRoutes());
+      beforeEach(() => setupRoutes())
 
       it('generates an operationId', () => {
-        expect(routerInstance.toSwagger().paths["/api/something/{id}"]["put"]["operationId"]).to.eql("/api/something/{id}/put")
-      });
+        expect(routerInstance.toSwagger().paths['/api/something/{id}']['put']['operationId']).to.eql('/api/something/{id}/put')
+      })
     })
   })
 
@@ -433,7 +433,7 @@ describe('router', () => {
           '/api/something/{id}': {
             put: {
               tags: ['Something'],
-              operationId: "/api/something/{id}/put",
+              operationId: '/api/something/{id}/put',
               summary: 'This route is about something',
               description: 'This route does something',
               responses: {

--- a/test/integration/router.test.js
+++ b/test/integration/router.test.js
@@ -285,6 +285,22 @@ describe('router', () => {
         expect(response.body).to.eql({ id: 123 })
       })
     })
+
+    describe('when an operationId is given', () => {
+      beforeEach(() => setupRoutes({ routeOpts: { operationId: "updateSomething" } }));
+
+      it('sets the operationId', () => {
+        expect(routerInstance.toSwagger().paths["/api/something/{id}"]["put"]["operationId"]).to.eql("updateSomething")
+      });
+    })
+
+    describe('when an operationId is not given', () => {
+      beforeEach(() => setupRoutes());
+
+      it('generates an operationId', () => {
+        expect(routerInstance.toSwagger().paths["/api/something/{id}"]["put"]["operationId"]).to.eql("/api/something/{id}/put")
+      });
+    })
   })
 
   describe('response validation', () => {
@@ -417,6 +433,7 @@ describe('router', () => {
           '/api/something/{id}': {
             put: {
               tags: ['Something'],
+              operationId: "/api/something/{id}/put",
               summary: 'This route is about something',
               description: 'This route does something',
               responses: {


### PR DESCRIPTION
* Adds operationIds to the schema https://swagger.io/docs/specification/paths-and-operations/
* Accept handlers with their own type specifications
* Fix issue with CircleCI cache (not sure why this started failing now)