### PR TITLE
Ensure we console.error all server errors

### DIFF
--- a/lib/middleware/error-handler.js
+++ b/lib/middleware/error-handler.js
@@ -2,8 +2,11 @@ const { HTTPError, ServerError } = require('../errors')
 
 module.exports = exports = (err, req, res, next) => {
   if (!(err instanceof HTTPError)) {
-    console.error('Unexpected error', err)
     err = new ServerError(err.message || 'Something went wrong')
+  }
+
+  if (err instanceof ServerError) {
+    console.error('Unexpected error', err)
   }
 
   res.status(err.code).json(err.responseJson)


### PR DESCRIPTION
Previous Behaviour:

* Unhandled exceptions are logged to the console
* Handled HTTP errors are not logged to the console

New Behaviour

* Unhandled exceptions are logged to the console
* Handled server errors are logged to the console
* Other handled http errors are not logged to the console

An example of where this makes a difference: https://github.com/lux-group/svc-public-offer/blob/master/src/utils/request/responseInterceptor.js#L5

Because we're explicitly throwing a ServerError, the details don't get logged. IMO they should because an unexpected event has occurred and it's useful to be able to see the stack trace.

THAT ALL SAID - there's probably an argument for not throwing the server error like we are in Public Offer. This library is responsible for API level logic, whereas its exception are being used in the logic of communicating with other APIs!

Anyway I don't think there's harm in this change regardless. Let me know if you disagree.