### PR TITLE
Make sure we log the original error

### DIFF
--- a/lib/middleware/error-handler.js
+++ b/lib/middleware/error-handler.js
@@ -2,11 +2,10 @@ const { HTTPError, ServerError } = require('../errors')
 
 module.exports = exports = (err, req, res, next) => {
   if (!(err instanceof HTTPError)) {
+    console.error('Unexpected error', err) // log the original error
     err = new ServerError(err.message || 'Something went wrong')
-  }
-
-  if (err instanceof ServerError) {
-    console.error('Unexpected error', err)
+  } else if (err instanceof ServerError) {
+    console.error('Unexpected error', err) // log manually thrown server errors too!
   }
 
   res.status(err.code).json(err.responseJson)


### PR DESCRIPTION
Following on from https://github.com/lux-group/router/pull/25 - we should still log the original error! Otherwise its stack trace is lost to the abyss.