### PR TITLE
Generate OpenAPI correctly for array items

### DIFF
--- a/lib/generate-swagger.js
+++ b/lib/generate-swagger.js
@@ -19,6 +19,9 @@ const jsonSchemaToParameters = (schema, { into }) => {
     if (schemaProperty.enum) {
       result.enum = schemaProperty.enum
     }
+    if (schemaProperty.items) {
+      result.items = schemaProperty.items
+    }
     return result
   })
 }

--- a/test/integration/router.test.js
+++ b/test/integration/router.test.js
@@ -43,7 +43,8 @@ const schema = {
   request: {
     query: s.objectWithOnly({
       hello: s.enum({ type: 'string', values: ['hi', 'hello'], verbose: true, description: 'Different ways to greet someone' }),
-      world: s.string({ min: 2, max: 4 })
+      world: s.string({ min: 2, max: 4 }),
+      foo: s.array({ of: s.string(), optional: true })
     }),
     params: s.objectWithOnly({
       id: s.integer({ parse: true })
@@ -458,6 +459,7 @@ describe('router', () => {
                   enum: ['hi', 'hello']
                 },
                 { name: 'world', in: 'query', required: true, type: 'string' },
+                { name: 'foo', in: 'query', required: false, type: 'array', items: { 'type': 'string' } },
                 {
                   name: 'payload',
                   in: 'body',


### PR DESCRIPTION
As per the spec, arrays can have items which describe the type inside.