### PR TITLE
Generate definitions for oneOf

### DIFF
--- a/lib/generate-swagger.js
+++ b/lib/generate-swagger.js
@@ -82,14 +82,14 @@ const findNestedDefinition = (jsonSchema, definitions) => {
     findNestedDefinition(jsonSchema.items, definitions)
   } else if (jsonSchema.oneOf) {
     jsonSchema.oneOf = jsonSchema.oneOf.map(s => {
-      const {name} = s;
-      if (!name) return s;
+      const { name } = s
+      if (!name) return s
 
       addDefinitions(definitions, name, s)
       return {
         $ref: `#/definitions/${name}`
       }
-    });
+    })
   } else {
     for (let key in jsonSchema.properties) {
       let property = jsonSchema.properties[key]

--- a/lib/generate-swagger.js
+++ b/lib/generate-swagger.js
@@ -80,6 +80,16 @@ const findNestedDefinition = (jsonSchema, definitions) => {
     }
   } else if (jsonSchema.items) {
     findNestedDefinition(jsonSchema.items, definitions)
+  } else if (jsonSchema.oneOf) {
+    jsonSchema.oneOf = jsonSchema.oneOf.map(s => {
+      const {name} = s;
+      if (!name) return s;
+
+      addDefinitions(definitions, name, s)
+      return {
+        $ref: `#/definitions/${name}`
+      }
+    });
   } else {
     for (let key in jsonSchema.properties) {
       let property = jsonSchema.properties[key]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/router",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Wrapper around express router that provides validation and documentation out of the box",
   "main": "index.js",
   "types": "index.d.ts",

--- a/test/generate-swagger.test.js
+++ b/test/generate-swagger.test.js
@@ -1,195 +1,195 @@
-const { expect } = require("chai");
-const s = require("strummer");
-const generateSwagger = require("../lib/generate-swagger");
+const { expect } = require('chai')
+const s = require('strummer')
+const generateSwagger = require('../lib/generate-swagger')
 
 const schemaA = s(
-  "A",
+  'A',
   s.object({
-    id: s.uuid(),
+    id: s.uuid()
   })
-);
+)
 
-describe("generateSwagger", () => {
-  it("creates definitions for partially named one ofs", () => {
+describe('generateSwagger', () => {
+  it('creates definitions for partially named one ofs', () => {
     const schemaB = s.object({
-      id: s.uuid(),
-    });
+      id: s.uuid()
+    })
 
-    const schema = s.object({ x: s.oneOf([schemaA, schemaB]) });
+    const schema = s.object({ x: s.oneOf([schemaA, schemaB]) })
 
     const swagger = generateSwagger(
       {
-        get: { "/": { schema: { request: {}, responses: { 200: schema } } } },
+        get: { '/': { schema: { request: {}, responses: { 200: schema } } } }
       },
       {}
-    );
+    )
 
     expect(swagger.definitions).to.eql({
       A: {
         properties: {
           id: {
-            format: "uuid",
-            type: "string",
-          },
+            format: 'uuid',
+            type: 'string'
+          }
         },
-        required: ["id"],
-        type: "object",
-      },
-    });
+        required: ['id'],
+        type: 'object'
+      }
+    })
 
     expect(
-      swagger.paths["/"]["get"]["responses"]["200"]["schema"]["properties"]
+      swagger.paths['/']['get']['responses']['200']['schema']['properties']
     ).to.eql({
       x: {
         oneOf: [
           {
-            $ref: "#/definitions/A",
+            $ref: '#/definitions/A'
           },
           {
             properties: {
               id: {
-                format: "uuid",
-                type: "string",
-              },
+                format: 'uuid',
+                type: 'string'
+              }
             },
-            required: ["id"],
-            type: "object",
-          },
+            required: ['id'],
+            type: 'object'
+          }
         ],
-        type: "object",
-      },
-    });
-  });
+        type: 'object'
+      }
+    })
+  })
 
-  it("creates definitions for one of", () => {
+  it('creates definitions for one of', () => {
     const schemaB = s(
-      "B",
+      'B',
       s.object({
-        id: s.uuid(),
+        id: s.uuid()
       })
-    );
+    )
 
-    const schema = s.object({ x: s.oneOf([schemaA, schemaB]) });
+    const schema = s.object({ x: s.oneOf([schemaA, schemaB]) })
 
     const swagger = generateSwagger(
       {
-        get: { "/": { schema: { request: {}, responses: { 200: schema } } } },
+        get: { '/': { schema: { request: {}, responses: { 200: schema } } } }
       },
       {}
-    );
+    )
 
     expect(
-      swagger.paths["/"]["get"]["responses"]["200"]["schema"]["properties"]
+      swagger.paths['/']['get']['responses']['200']['schema']['properties']
     ).to.eql({
       x: {
         oneOf: [
           {
-            $ref: "#/definitions/A",
+            $ref: '#/definitions/A'
           },
           {
-            $ref: "#/definitions/B",
-          },
+            $ref: '#/definitions/B'
+          }
         ],
-        type: "object",
-      },
-    });
+        type: 'object'
+      }
+    })
 
     expect(swagger.definitions).to.eql({
       A: {
         properties: {
           id: {
-            format: "uuid",
-            type: "string",
-          },
+            format: 'uuid',
+            type: 'string'
+          }
         },
-        required: ["id"],
-        type: "object",
+        required: ['id'],
+        type: 'object'
       },
       B: {
         properties: {
           id: {
-            format: "uuid",
-            type: "string",
-          },
+            format: 'uuid',
+            type: 'string'
+          }
         },
-        required: ["id"],
-        type: "object",
-      },
-    });
-  });
+        required: ['id'],
+        type: 'object'
+      }
+    })
+  })
 
-  it("creates definitions for arrays of arrays", () => {
+  it('creates definitions for arrays of arrays', () => {
     const rateSchema = s('rate', s.object({
       id: s.uuid()
-    }));
+    }))
 
     const packageSchema = s(
-      "package",
+      'package',
       s.object({ id: s.uuid(), rates: s.array({ of: rateSchema }) })
-    );
+    )
 
     const okResponseSchema = s.object({
       id: s.number(),
-      packages: s.array({ of: packageSchema }),
-    });
+      packages: s.array({ of: packageSchema })
+    })
 
     const swagger = generateSwagger(
       {
         get: {
-          "/": {
-            schema: { request: {}, responses: { 200: okResponseSchema } },
-          },
-        },
+          '/': {
+            schema: { request: {}, responses: { 200: okResponseSchema } }
+          }
+        }
       },
       {}
-    );
+    )
 
     expect(swagger.definitions).to.eql({
       package: {
         properties: {
           id: {
-            format: "uuid",
-            type: "string",
+            format: 'uuid',
+            type: 'string'
           },
           rates: {
             items: {
-              $ref: "#/definitions/rate",
+              $ref: '#/definitions/rate'
             },
-            type: "array",
-          },
+            type: 'array'
+          }
         },
-        required: ["id", "rates"],
-        type: "object",
+        required: ['id', 'rates'],
+        type: 'object'
       },
       rate: {
         properties: {
           id: {
-            format: "uuid",
-            type: "string",
-          },
+            format: 'uuid',
+            type: 'string'
+          }
         },
-        required: ["id"],
-        type: "object",
-      },
-    });
+        required: ['id'],
+        type: 'object'
+      }
+    })
 
-    expect(swagger.paths["/"]["get"]["responses"]["200"]).to.eql({
-      description: "200 response",
+    expect(swagger.paths['/']['get']['responses']['200']).to.eql({
+      description: '200 response',
       schema: {
         properties: {
           id: {
-            type: "number",
+            type: 'number'
           },
           packages: {
             items: {
-              $ref: "#/definitions/package",
+              $ref: '#/definitions/package'
             },
-            type: "array",
-          },
+            type: 'array'
+          }
         },
-        required: ["id", "packages"],
-        type: "object",
-      },
-    });
-  });
-});
+        required: ['id', 'packages'],
+        type: 'object'
+      }
+    })
+  })
+})

--- a/test/generate-swagger.test.js
+++ b/test/generate-swagger.test.js
@@ -1,78 +1,195 @@
-const { expect } = require('chai')
-const s = require('strummer')
-const generateSwagger = require('../lib/generate-swagger')
+const { expect } = require("chai");
+const s = require("strummer");
+const generateSwagger = require("../lib/generate-swagger");
 
-describe('generateSwagger', () => {
-  it('creates definitions for arrays of arrays', () => {
+const schemaA = s(
+  "A",
+  s.object({
+    id: s.uuid(),
+  })
+);
+
+describe("generateSwagger", () => {
+  it("creates definitions for partially named one ofs", () => {
+    const schemaB = s.object({
+      id: s.uuid(),
+    });
+
+    const schema = s.object({ x: s.oneOf([schemaA, schemaB]) });
+
+    const swagger = generateSwagger(
+      {
+        get: { "/": { schema: { request: {}, responses: { 200: schema } } } },
+      },
+      {}
+    );
+
+    expect(swagger.definitions).to.eql({
+      A: {
+        properties: {
+          id: {
+            format: "uuid",
+            type: "string",
+          },
+        },
+        required: ["id"],
+        type: "object",
+      },
+    });
+
+    expect(
+      swagger.paths["/"]["get"]["responses"]["200"]["schema"]["properties"]
+    ).to.eql({
+      x: {
+        oneOf: [
+          {
+            $ref: "#/definitions/A",
+          },
+          {
+            properties: {
+              id: {
+                format: "uuid",
+                type: "string",
+              },
+            },
+            required: ["id"],
+            type: "object",
+          },
+        ],
+        type: "object",
+      },
+    });
+  });
+
+  it("creates definitions for one of", () => {
+    const schemaB = s(
+      "B",
+      s.object({
+        id: s.uuid(),
+      })
+    );
+
+    const schema = s.object({ x: s.oneOf([schemaA, schemaB]) });
+
+    const swagger = generateSwagger(
+      {
+        get: { "/": { schema: { request: {}, responses: { 200: schema } } } },
+      },
+      {}
+    );
+
+    expect(
+      swagger.paths["/"]["get"]["responses"]["200"]["schema"]["properties"]
+    ).to.eql({
+      x: {
+        oneOf: [
+          {
+            $ref: "#/definitions/A",
+          },
+          {
+            $ref: "#/definitions/B",
+          },
+        ],
+        type: "object",
+      },
+    });
+
+    expect(swagger.definitions).to.eql({
+      A: {
+        properties: {
+          id: {
+            format: "uuid",
+            type: "string",
+          },
+        },
+        required: ["id"],
+        type: "object",
+      },
+      B: {
+        properties: {
+          id: {
+            format: "uuid",
+            type: "string",
+          },
+        },
+        required: ["id"],
+        type: "object",
+      },
+    });
+  });
+
+  it("creates definitions for arrays of arrays", () => {
     const rateSchema = s('rate', s.object({
       id: s.uuid()
-    }))
+    }));
 
-    const packageSchema = s('package', s.object({ id: s.uuid(), rates: s.array({ of: rateSchema }) }))
+    const packageSchema = s(
+      "package",
+      s.object({ id: s.uuid(), rates: s.array({ of: rateSchema }) })
+    );
 
     const okResponseSchema = s.object({
       id: s.number(),
-      packages: s.array({ of: packageSchema })
-    })
+      packages: s.array({ of: packageSchema }),
+    });
 
-    const swagger = generateSwagger({
-      get: { '/': { schema: { request: {}, responses: { 200: okResponseSchema } } } }
-    }, {})
+    const swagger = generateSwagger(
+      {
+        get: {
+          "/": {
+            schema: { request: {}, responses: { 200: okResponseSchema } },
+          },
+        },
+      },
+      {}
+    );
 
     expect(swagger.definitions).to.eql({
-      'package': {
-        'properties': {
-          'id': {
-            'format': 'uuid',
-            'type': 'string'
+      package: {
+        properties: {
+          id: {
+            format: "uuid",
+            type: "string",
           },
-          'rates': {
-            'items': {
-              '$ref': '#/definitions/rate'
+          rates: {
+            items: {
+              $ref: "#/definitions/rate",
             },
-            'type': 'array'
-          }
+            type: "array",
+          },
         },
-        'required': [
-          'id',
-          'rates'
-        ],
-        'type': 'object'
+        required: ["id", "rates"],
+        type: "object",
       },
-      'rate': {
-        'properties': {
-          'id': {
-            'format': 'uuid',
-            'type': 'string'
-          }
-        },
-        'required': [
-          'id'
-        ],
-        'type': 'object'
-      }
-    })
-
-    expect(swagger.paths['/']['get']['responses']['200']).to.eql({
-      'description': '200 response',
-      'schema': {
-        'properties': {
-          'id': {
-            'type': 'number'
+      rate: {
+        properties: {
+          id: {
+            format: "uuid",
+            type: "string",
           },
-          'packages': {
-            'items': {
-              '$ref': '#/definitions/package'
-            },
-            'type': 'array'
-          }
         },
-        'required': [
-          'id',
-          'packages'
-        ],
-        'type': 'object'
-      }
-    })
-  })
-})
+        required: ["id"],
+        type: "object",
+      },
+    });
+
+    expect(swagger.paths["/"]["get"]["responses"]["200"]).to.eql({
+      description: "200 response",
+      schema: {
+        properties: {
+          id: {
+            type: "number",
+          },
+          packages: {
+            items: {
+              $ref: "#/definitions/package",
+            },
+            type: "array",
+          },
+        },
+        required: ["id", "packages"],
+        type: "object",
+      },
+    });
+  });
+});


### PR DESCRIPTION
We're not generating definitions for schemas inside oneOf matchers. With this change, we do.

