### PR TITLE
Allow json options to be passed per route

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,13 +13,13 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "yarn.lock" }}
+            - v1-dependencies-{{ checksum "package.json" }}
             - v1-dependencies-
 
       - run: npm install
 
       - save_cache:
-          key: v1-dependencies-{{ checksum "yarn.lock" }}
+          key: v1-dependencies-{{ checksum "package.json" }}
           paths:
             - ./node_modules
 

--- a/README.md
+++ b/README.md
@@ -28,12 +28,10 @@ yarn add @sentry/node # optional for Sentry support
 
 ```js
 const express = require('express')
-const bodyParser = require('body-parser')
 const s = require('strummer')
 const { router } = require('@luxuryescapes/router')
 
 const server = express()
-server.use(bodyParser.json())
 
 // tags, paths, definitions get added from the route definitions
 // everything else is provided here
@@ -108,6 +106,7 @@ routerInstance.put({
   logRequests: true, // true = request and response will be logged DEFAULT: false,
   correlationIdExtractor: (req, res) => { return req.params.id }, // for use when logRequests is TRUE, this will be used to extract the correlationid from the request/response for use in the log output DEFAULT: null
   logger: new Bunyan(), // you can pass in a logger that will be used for logging output , must have methods `log`, `warn` and `error` DEFAULT: console
+  jsonLimit: '20mb', // Controls the maximum request body size. If this is a number, then the value specifies the number of bytes; if it is a string, the value is passed to the bytes library for parsing.
 })
 
 // this is the endpoint that the swagger ui will be served on

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ routerInstance.put({
   logRequests: true, // true = request and response will be logged DEFAULT: false,
   correlationIdExtractor: (req, res) => { return req.params.id }, // for use when logRequests is TRUE, this will be used to extract the correlationid from the request/response for use in the log output DEFAULT: null
   logger: new Bunyan(), // you can pass in a logger that will be used for logging output , must have methods `log`, `warn` and `error` DEFAULT: console
-  jsonLimit: '20mb', // Controls the maximum request body size. If this is a number, then the value specifies the number of bytes; if it is a string, the value is passed to the bytes library for parsing.
+  jsonOptions: { limit: '20mb' }, // Options to be passed to express.json() DEFAULT: {}
 })
 
 // this is the endpoint that the swagger ui will be served on

--- a/lib/generate-swagger.js
+++ b/lib/generate-swagger.js
@@ -166,7 +166,7 @@ const generateRoutes = (routeDefinitions, existingTags) => {
     for (let path of Object.keys(routeDefinitions[method])) {
       const swaggerPath = path.replace(/\/:([a-zA-Z]*)/g, '/{$1}')
       let route = routeDefinitions[method][path]
-      if (!route.schema) continue;
+      if (!route.schema) continue
       if (!paths[swaggerPath]) {
         paths[swaggerPath] = {}
       }

--- a/lib/generate-swagger.js
+++ b/lib/generate-swagger.js
@@ -166,6 +166,7 @@ const generateRoutes = (routeDefinitions, existingTags) => {
     for (let path of Object.keys(routeDefinitions[method])) {
       const swaggerPath = path.replace(/\/:([a-zA-Z]*)/g, '/{$1}')
       let route = routeDefinitions[method][path]
+      if (!route.schema) continue;
       if (!paths[swaggerPath]) {
         paths[swaggerPath] = {}
       }

--- a/lib/router.js
+++ b/lib/router.js
@@ -1,3 +1,4 @@
+const express = require('express')
 const swaggerUi = require('swagger-ui-express')
 
 const generateSwagger = require('./generate-swagger')
@@ -13,9 +14,9 @@ const handle = (
   method,
   routeDefinitions,
   { validateResponses, logRequests, correlationIdExtractor, logger },
-  { url, operationId, preHandlers, handlers, schema, isPublic, tags, summary, description, warnOnRequestValidationError }
+  { url, operationId, preHandlers, handlers, schema, isPublic, tags, summary, description, warnOnRequestValidationError, jsonLimit }
 ) => {
-  let _handlers = []
+  let _handlers = [express.json({ limit: jsonLimit || '100kb' })]
 
   if (routeDefinitions[method][url]) {
     throw new Error(`Route already defined: (${method}) ${url}`)

--- a/lib/router.js
+++ b/lib/router.js
@@ -14,9 +14,9 @@ const handle = (
   method,
   routeDefinitions,
   { validateResponses, logRequests, correlationIdExtractor, logger },
-  { url, operationId, preHandlers, handlers, schema, isPublic, tags, summary, description, warnOnRequestValidationError, jsonLimit }
+  { url, operationId, preHandlers, handlers, schema, isPublic, tags, summary, description, warnOnRequestValidationError, jsonOptions }
 ) => {
-  let _handlers = [express.json({ limit: jsonLimit || '100kb' })]
+  let _handlers = [express.json(jsonOptions || {})]
 
   if (routeDefinitions[method][url]) {
     throw new Error(`Route already defined: (${method}) ${url}`)

--- a/lib/utils/uuid.js
+++ b/lib/utils/uuid.js
@@ -1,5 +1,5 @@
-const uuid = require('uuid/v4')
+const crypto = require('crypto')
 
 module.exports = {
-  get: () => uuid()
+  get: crypto.randomUUID
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   },
   "homepage": "https://github.com/brandsExclusive/router#readme",
   "devDependencies": {
-    "body-parser": "^1.19.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "chai-http": "^4.3.0",
@@ -37,8 +36,7 @@
   "dependencies": {
     "@sentry/node": "^6.8.0",
     "openapi-typescript": "^4.0.2",
-    "swagger-ui-express": "^4.0.6",
-    "uuid": "^3.3.3"
+    "swagger-ui-express": "^4.0.6"
   },
   "standard": {
     "globals": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/router",
-  "version": "0.9.0",
+  "version": "1.0.0",
   "description": "Wrapper around express router that provides validation and documentation out of the box",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/router",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "Wrapper around express router that provides validation and documentation out of the box",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -47,5 +47,8 @@
       "beforeEach",
       "afterEach"
     ]
+  },
+  "engines": {
+    "node": ">=14.17.0"
   }
 }

--- a/test/integration/router.test.js
+++ b/test/integration/router.test.js
@@ -1,7 +1,6 @@
 const chai = require('chai')
 const sinon = require('sinon')
 const express = require('express')
-const bodyParser = require('body-parser')
 const s = require('strummer')
 
 const expect = chai.expect
@@ -67,7 +66,6 @@ describe('router', () => {
 
   beforeEach(async () => {
     server = express()
-    server.use(bodyParser.json())
   })
 
   afterEach(async () => {

--- a/test/integration/router.test.js
+++ b/test/integration/router.test.js
@@ -97,7 +97,7 @@ describe('router', () => {
     })
     routerInstance.post({
       url: '/api/echo',
-      handlers: [echoHandler],
+      handlers: [echoHandler]
     })
     routerInstance.serveSwagger('/docs')
     server.use(errorHandler)
@@ -142,11 +142,11 @@ describe('router', () => {
       const response = await chai.request(app)
         .post('/api/echo')
         .set('content-type', 'text/plain')
-        .send("ABC")
+        .send('ABC')
       expect(response.status).to.eql(200)
       expect(response.body).to.eql({ body: 'ABC' })
     })
-  });
+  })
 
   describe('request logging', () => {
     describe('when disabled', () => {


### PR DESCRIPTION
We want to be able to provide a size limit on the JSON payloads per endpoint.

This PR adds the JSON middleware to all handlers and allows options to be passed to it.

So you would do:

```
router.put({
  url: '/api/passport-details',
  jsonOptions: { limit: '20mb' },
  handler...
})
```

Also replaced uuid dependency with native crypto module and made Node 14 a requirement.