### PR TITLE
Generate API spec as OpenAPI v3.0.3 

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ const server = express()
 // tags, paths, definitions get added from the route definitions
 // everything else is provided here
 const swaggerBaseProperties = {
-  swagger: '2.0',
+  openapi: '3.0.3',
   info: {
     description: 'This is my api',
     version: '1.0.0',

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ const server = express()
 // tags, paths, definitions get added from the route definitions
 // everything else is provided here
 const swaggerBaseProperties = {
-  openapi: '3.0.3',
   info: {
     description: 'This is my api',
     version: '1.0.0',
@@ -238,11 +237,12 @@ Now, anytime you run `yarn generate-types` the types will be regenerated for you
 
 ### Upgrading from v1 to v2
 
-Where you instantiate your router, change:
+Where you instantiate your router, remove the `swagger` property:
 
 ```
 swaggerBaseProperties: {
   swagger: "2.0",
+  info: { ... }
   ...
 ```
 
@@ -250,7 +250,7 @@ to
 
 ```
 swaggerBaseProperties: {
-  openapi: "3.0.3",
+  info: { ... }
   ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -234,6 +234,30 @@ Where the path is to the file you just created.
 
 Now, anytime you run `yarn generate-types` the types will be regenerated for you to use in your controllers.
 
+## Upgrade Guides
+
+### Upgrading from v1 to v2
+
+Where you instantiate your router, change:
+
+```
+swaggerBaseProperties: {
+  swagger: "2.0",
+  ...
+```
+
+to
+
+```
+swaggerBaseProperties: {
+  openapi: "3.0.3",
+  ...
+```
+
+### Upgrading to v1
+
+The use of [Node's crypto module](https://nodejs.org/api/crypto.html) means that versions below v15.6.0 and v14.17.0 are no longer supported. Upgrade your Node version to an appropriate version.
+
 ## Contributing
 
 Make your change, make a PR

--- a/index.d.ts
+++ b/index.d.ts
@@ -36,7 +36,7 @@ declare module "@luxuryescapes/router" {
     sentryDSN?: string;
     appEnv?: AppEnv;
     swaggerBaseProperties?: {
-      swagger: string;
+      openapi: "3";
       info: {
         description: string;
         version: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -36,7 +36,6 @@ declare module "@luxuryescapes/router" {
     sentryDSN?: string;
     appEnv?: AppEnv;
     swaggerBaseProperties?: {
-      openapi: "3.0.3";
       info: {
         description: string;
         version: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -36,7 +36,7 @@ declare module "@luxuryescapes/router" {
     sentryDSN?: string;
     appEnv?: AppEnv;
     swaggerBaseProperties?: {
-      openapi: "3";
+      openapi: "3.0.2";
       info: {
         description: string;
         version: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -36,7 +36,7 @@ declare module "@luxuryescapes/router" {
     sentryDSN?: string;
     appEnv?: AppEnv;
     swaggerBaseProperties?: {
-      openapi: "3.0.2";
+      openapi: "3.0.3";
       info: {
         description: string;
         version: string;

--- a/lib/generate-swagger.js
+++ b/lib/generate-swagger.js
@@ -8,20 +8,14 @@ const jsonSchemaToParameters = (schema, { into }) => {
       name: property,
       in: into,
       required: schema.required ? schema.required.includes(property) : false,
-      schema: { type: schemaProperty.type }
+      schema: schemaProperty
     }
     if (schemaProperty.format) {
       result.format = schemaProperty.format // TODO
     }
     if (schemaProperty.description) {
       result.description = schemaProperty.description
-    }
-    if (schemaProperty.enum) {
-      result.schema = { enum: schemaProperty.enum }
-      if (schemaProperty.type) result.schema.type = schemaProperty.type
-    }
-    if (schemaProperty.items) {
-      result.schema.items = schemaProperty.items
+      delete schemaProperty.description
     }
     if (schemaProperty.oneOf) {
       result.oneOf = schemaProperty.oneOf

--- a/lib/generate-swagger.js
+++ b/lib/generate-swagger.js
@@ -10,16 +10,9 @@ const jsonSchemaToParameters = (schema, { into }) => {
       required: schema.required ? schema.required.includes(property) : false,
       schema: schemaProperty
     }
-    if (schemaProperty.format) {
-      result.format = schemaProperty.format // TODO
-    }
     if (schemaProperty.description) {
       result.description = schemaProperty.description
       delete schemaProperty.description
-    }
-    if (schemaProperty.oneOf) {
-      result.oneOf = schemaProperty.oneOf
-      result.type = schemaProperty.oneOf.map(x => x.type) // TODO
     }
     return result
   })

--- a/lib/generate-swagger.js
+++ b/lib/generate-swagger.js
@@ -72,8 +72,7 @@ const generateAuthDetails = (route) => route.isPublic ? [] : [{
   in: 'header',
   description: 'Cookie',
   required: true,
-  default: 'access_token={{token}}',
-  schema: { type: 'string' }
+  schema: { type: 'string', default: 'access_token={{token}}' }
 }]
 
 const findNestedDefinition = (jsonSchema, definitions) => {

--- a/lib/generate-swagger.js
+++ b/lib/generate-swagger.js
@@ -8,7 +8,7 @@ const jsonSchemaToParameters = (schema, { into }) => {
       name: property,
       in: into,
       required: schema.required ? schema.required.includes(property) : false,
-      type: schemaProperty.type
+      schema: { type: schemaProperty.type }
     }
     if (schemaProperty.format) {
       result.format = schemaProperty.format

--- a/lib/generate-swagger.js
+++ b/lib/generate-swagger.js
@@ -53,7 +53,7 @@ const generatePayload = (schema, definitions) => {
     let name = jsonSchema.name
     addDefinitions(definitions, jsonSchema.name, jsonSchema)
     jsonSchema = {
-      $ref: `#/definitions/${name}`
+      $ref: `#/components/schemas/${name}`
     }
   } else {
     findNestedDefinition(jsonSchema, definitions)
@@ -72,7 +72,7 @@ const generateAuthDetails = (route) => route.isPublic ? [] : [{
   description: 'Cookie',
   required: true,
   default: 'access_token={{token}}',
-  type: 'string'
+  schema: { type: 'string' }
 }]
 
 const findNestedDefinition = (jsonSchema, definitions) => {
@@ -80,7 +80,7 @@ const findNestedDefinition = (jsonSchema, definitions) => {
     let name = jsonSchema.items.name
     addDefinitions(definitions, name, jsonSchema.items)
     jsonSchema.items = {
-      $ref: `#/definitions/${name}`
+      $ref: `#/components/schemas/${name}`
     }
   } else if (jsonSchema.items) {
     findNestedDefinition(jsonSchema.items, definitions)
@@ -91,7 +91,7 @@ const findNestedDefinition = (jsonSchema, definitions) => {
 
       addDefinitions(definitions, name, s)
       return {
-        $ref: `#/definitions/${name}`
+        $ref: `#/components/schemas/${name}`
       }
     })
   } else {
@@ -101,13 +101,13 @@ const findNestedDefinition = (jsonSchema, definitions) => {
         let name = property.name
         addDefinitions(definitions, property.name, property)
         jsonSchema.properties[key] = {
-          $ref: `#/definitions/${name}`
+          $ref: `#/components/schemas/${name}`
         }
       } else if (property.items && property.items.name) {
         let name = property.items.name
         addDefinitions(definitions, name, property.items)
         property.items = {
-          $ref: `#/definitions/${name}`
+          $ref: `#/components/schemas/${name}`
         }
       } else {
         findNestedDefinition(property, definitions)
@@ -137,16 +137,24 @@ const generateResponseDefinitions = (schema, definitions) => {
     if (name) {
       addDefinitions(definitions, name, jsonSchema)
       responses[responseCode] = {
-        schema: {
-          $ref: `#/definitions/${name}`
+        content: {
+          'application/json': {
+            schema: {
+              $ref: `#/definitions/${name}`
+            },
+          }
         },
         description: `${responseCode} response`
       }
     } else {
       findNestedDefinition(jsonSchema, definitions)
       responses[responseCode] = {
-        schema: jsonSchema,
-        description: `${responseCode} response`
+        content: {
+          'application/json': {
+            schema: jsonSchema,
+            description: `${responseCode} response`
+          }
+        }
       }
     }
   }
@@ -208,7 +216,7 @@ const generateSwagger = (routeDefinitions, baseProperties) => {
   return {
     ...baseProperties,
     paths: result.paths,
-    definitions: result.definitions,
+    components: { schemas: result.definitions },
     tags: existingTags.concat(result.tags)
   }
 }

--- a/lib/generate-swagger.js
+++ b/lib/generate-swagger.js
@@ -11,7 +11,7 @@ const jsonSchemaToParameters = (schema, { into }) => {
       schema: { type: schemaProperty.type }
     }
     if (schemaProperty.format) {
-      result.format = schemaProperty.format
+      result.format = schemaProperty.format // TODO
     }
     if (schemaProperty.description) {
       result.description = schemaProperty.description
@@ -21,11 +21,11 @@ const jsonSchemaToParameters = (schema, { into }) => {
       if (schemaProperty.type) result.schema.type = schemaProperty.type
     }
     if (schemaProperty.items) {
-      result.items = schemaProperty.items
+      result.schema.items = schemaProperty.items
     }
     if (schemaProperty.oneOf) {
       result.oneOf = schemaProperty.oneOf
-      result.type = schemaProperty.oneOf.map(x => x.type)
+      result.type = schemaProperty.oneOf.map(x => x.type) // TODO
     }
     return result
   })

--- a/lib/generate-swagger.js
+++ b/lib/generate-swagger.js
@@ -17,7 +17,8 @@ const jsonSchemaToParameters = (schema, { into }) => {
       result.description = schemaProperty.description
     }
     if (schemaProperty.enum) {
-      result.enum = schemaProperty.enum
+      result.schema = { enum: schemaProperty.enum }
+      if (schemaProperty.type) result.schema.type = schemaProperty.type
     }
     if (schemaProperty.items) {
       result.items = schemaProperty.items
@@ -152,9 +153,9 @@ const generateResponseDefinitions = (schema, definitions) => {
         content: {
           'application/json': {
             schema: jsonSchema,
-            description: `${responseCode} response`
           }
-        }
+        },
+        description: `${responseCode} response`
       }
     }
   }

--- a/lib/generate-swagger.js
+++ b/lib/generate-swagger.js
@@ -202,6 +202,7 @@ const generateSwagger = (routeDefinitions, baseProperties) => {
   const result = generateRoutes(routeDefinitions, existingTags)
   return {
     ...baseProperties,
+    openapi: '3.0.3',
     paths: result.paths,
     components: { schemas: result.definitions },
     tags: existingTags.concat(result.tags)

--- a/lib/generate-swagger.js
+++ b/lib/generate-swagger.js
@@ -128,7 +128,7 @@ const generateResponseDefinitions = (schema, definitions) => {
           'application/json': {
             schema: {
               $ref: `#/definitions/${name}`
-            },
+            }
           }
         },
         description: `${responseCode} response`
@@ -138,7 +138,7 @@ const generateResponseDefinitions = (schema, definitions) => {
       responses[responseCode] = {
         content: {
           'application/json': {
-            schema: jsonSchema,
+            schema: jsonSchema
           }
         },
         description: `${responseCode} response`

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "dirty-chai": "^2.0.1",
     "express": "^4.17.1",
     "mocha": "^9.0.2",
+    "openapi-schema-validator": "^9.3.1",
     "sinon": "^7.5.0",
     "snazzy": "^8.0.0",
     "standard": "^12.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/router",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Wrapper around express router that provides validation and documentation out of the box",
   "main": "index.js",
   "types": "index.d.ts",

--- a/test/generate-swagger.test.js
+++ b/test/generate-swagger.test.js
@@ -378,6 +378,68 @@ describe('generateSwagger', () => {
     })
   })
 
+  it('generates formatted parameters', () => {
+    const swagger = generateSwagger(
+      {
+        get: {
+          '/': {
+            schema: {
+              request: {
+                query: s.object({
+                  ids: s.array({ of: s.uuid() })
+                })
+              }
+            }
+          }
+        }
+      },
+      {}
+    )
+
+    expect(swagger.paths['/']['get'].parameters[0]).to.eql({
+      "in": "query",
+      "name": "ids",
+      "required": true,
+      "schema": {
+        "type": "array",
+        "items": {
+          "format": "uuid",
+          "type": "string"
+        },
+      }
+    })
+  })
+
+  it('handles descriptions', () => {
+    const swagger = generateSwagger(
+      {
+        get: {
+          '/': {
+            schema: {
+              request: {
+                params: s.object({
+                  id: s.uuid({ description: "The ID to lookup" })
+                })
+              }
+            }
+          }
+        }
+      },
+      {}
+    ) 
+
+    expect(swagger.paths['/']['get'].parameters[0]).to.eql({
+      "in": "path",
+      "name": "id",
+      "required": true,
+      "description": "The ID to lookup",
+      "schema": {
+        "format": "uuid",
+        "type": "string"
+      }
+    })
+  })
+
   it('generates a valid openapi', async () => {
     const rateSchema = s('rate', s.object({
       id: s.uuid()

--- a/test/generate-swagger.test.js
+++ b/test/generate-swagger.test.js
@@ -347,6 +347,37 @@ describe('generateSwagger', () => {
     })
   })
 
+  it('generates arrays', () => {
+    const swagger = generateSwagger(
+      {
+        get: {
+          '/': {
+            schema: {
+              request: {
+                query: s.object({
+                  ids: s.array({ of: s.string() })
+                })
+              }
+            }
+          }
+        }
+      },
+      {}
+    )
+
+    expect(swagger.paths['/']['get'].parameters[0]).to.eql({
+      "in": "query",
+      "name": "ids",
+      "required": true,
+      "schema": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+      }
+    })
+  })
+
   it('generates a valid openapi', async () => {
     const rateSchema = s('rate', s.object({
       id: s.uuid()

--- a/test/generate-swagger.test.js
+++ b/test/generate-swagger.test.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai')
 const s = require('strummer')
-var OpenAPISchemaValidator = require('openapi-schema-validator').default;
+var OpenAPISchemaValidator = require('openapi-schema-validator').default
 
 const generateSwagger = require('../lib/generate-swagger')
 
@@ -291,7 +291,7 @@ describe('generateSwagger', () => {
     expect(swagger.paths['/']['get']['responses']['200']['content']['application/json']).to.eql({
       'schema': {
         '$ref': '#/definitions/rate'
-      },
+      }
     })
   })
 
@@ -312,12 +312,12 @@ describe('generateSwagger', () => {
         }
       },
       {}
-    ) 
+    )
     expect(swagger.paths['/']['get'].parameters[0]).to.eql({
-      "in": "query",
-      "name": "page",
-      "required": true,
-      "schema": { "type": "integer" }
+      'in': 'query',
+      'name': 'page',
+      'required': true,
+      'schema': { 'type': 'integer' }
     })
   })
 
@@ -329,7 +329,7 @@ describe('generateSwagger', () => {
             schema: {
               request: {
                 query: s.object({
-                  region: s.enum({ values: ['AU', 'NZ']})
+                  region: s.enum({ values: ['AU', 'NZ'] })
                 })
               },
               responses: {}
@@ -338,12 +338,12 @@ describe('generateSwagger', () => {
         }
       },
       {}
-    ) 
+    )
     expect(swagger.paths['/']['get'].parameters[0]).to.eql({
-      "in": "query",
-      "name": "region",
-      "required": true,
-      "schema": { "enum": ["AU", "NZ"] }
+      'in': 'query',
+      'name': 'region',
+      'required': true,
+      'schema': { 'enum': ['AU', 'NZ'] }
     })
   })
 
@@ -366,14 +366,14 @@ describe('generateSwagger', () => {
     )
 
     expect(swagger.paths['/']['get'].parameters[0]).to.eql({
-      "in": "query",
-      "name": "ids",
-      "required": true,
-      "schema": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
+      'in': 'query',
+      'name': 'ids',
+      'required': true,
+      'schema': {
+        'type': 'array',
+        'items': {
+          'type': 'string'
+        }
       }
     })
   })
@@ -397,15 +397,15 @@ describe('generateSwagger', () => {
     )
 
     expect(swagger.paths['/']['get'].parameters[0]).to.eql({
-      "in": "query",
-      "name": "ids",
-      "required": true,
-      "schema": {
-        "type": "array",
-        "items": {
-          "format": "uuid",
-          "type": "string"
-        },
+      'in': 'query',
+      'name': 'ids',
+      'required': true,
+      'schema': {
+        'type': 'array',
+        'items': {
+          'format': 'uuid',
+          'type': 'string'
+        }
       }
     })
   })
@@ -418,7 +418,7 @@ describe('generateSwagger', () => {
             schema: {
               request: {
                 params: s.object({
-                  id: s.uuid({ description: "The ID to lookup" })
+                  id: s.uuid({ description: 'The ID to lookup' })
                 })
               }
             }
@@ -426,16 +426,16 @@ describe('generateSwagger', () => {
         }
       },
       {}
-    ) 
+    )
 
     expect(swagger.paths['/']['get'].parameters[0]).to.eql({
-      "in": "path",
-      "name": "id",
-      "required": true,
-      "description": "The ID to lookup",
-      "schema": {
-        "format": "uuid",
-        "type": "string"
+      'in': 'path',
+      'name': 'id',
+      'required': true,
+      'description': 'The ID to lookup',
+      'schema': {
+        'format': 'uuid',
+        'type': 'string'
       }
     })
   })
@@ -463,7 +463,7 @@ describe('generateSwagger', () => {
               request: {
                 query: s.object({
                   page: s.integer(),
-                  region: s.enum({ values: ['AU', 'NZ']})
+                  region: s.enum({ values: ['AU', 'NZ'] })
                 })
               },
               responses: { 200: okResponseSchema }
@@ -471,8 +471,8 @@ describe('generateSwagger', () => {
           }
         }
       },
-      { openapi: '3.0.3', info: { title: "TEST API", version: 'x' } }
-    ) 
+      { openapi: '3.0.3', info: { title: 'TEST API', version: 'x' } }
+    )
     var validator = new OpenAPISchemaValidator({
       version: '3.0.3'
     })

--- a/test/generate-swagger.test.js
+++ b/test/generate-swagger.test.js
@@ -347,7 +347,7 @@ describe('generateSwagger', () => {
     })
   })
 
-  it('generates arrays', () => {
+  it('generates array parameters', () => {
     const swagger = generateSwagger(
       {
         get: {

--- a/test/generate-swagger.test.js
+++ b/test/generate-swagger.test.js
@@ -174,7 +174,6 @@ describe('generateSwagger', () => {
     })
 
     expect(swagger.paths['/']['get']['responses']['200']['content']['application/json']).to.eql({
-      description: '200 response',
       schema: {
         properties: {
           id: {
@@ -294,7 +293,7 @@ describe('generateSwagger', () => {
     })
   })
 
-  it('generates parameters', () => {
+  it('generates integer parameters', () => {
     const swagger = generateSwagger(
       {
         get: {
@@ -317,6 +316,32 @@ describe('generateSwagger', () => {
       "name": "page",
       "required": true,
       "schema": { "type": "integer" }
+    })
+  })
+
+  it('generates enum parameters', () => {
+    const swagger = generateSwagger(
+      {
+        get: {
+          '/': {
+            schema: {
+              request: {
+                query: s.object({
+                  region: s.enum({ values: ['AU', 'NZ']})
+                })
+              },
+              responses: {}
+            }
+          }
+        }
+      },
+      {}
+    ) 
+    expect(swagger.paths['/']['get'].parameters[0]).to.eql({
+      "in": "query",
+      "name": "region",
+      "required": true,
+      "schema": { "enum": ["AU", "NZ"] }
     })
   })
 })

--- a/test/generate-swagger.test.js
+++ b/test/generate-swagger.test.js
@@ -293,4 +293,30 @@ describe('generateSwagger', () => {
       },
     })
   })
+
+  it('generates parameters', () => {
+    const swagger = generateSwagger(
+      {
+        get: {
+          '/': {
+            schema: {
+              request: {
+                query: s.object({
+                  page: s.integer()
+                })
+              },
+              responses: {}
+            }
+          }
+        }
+      },
+      {}
+    ) 
+    expect(swagger.paths['/']['get'].parameters[0]).to.eql({
+      "in": "query",
+      "name": "page",
+      "required": true,
+      "schema": { "type": "integer" }
+    })
+  })
 })

--- a/test/generate-swagger.test.js
+++ b/test/generate-swagger.test.js
@@ -1,5 +1,7 @@
 const { expect } = require('chai')
 const s = require('strummer')
+var OpenAPISchemaValidator = require('openapi-schema-validator').default;
+
 const generateSwagger = require('../lib/generate-swagger')
 
 const schemaA = s(
@@ -343,5 +345,30 @@ describe('generateSwagger', () => {
       "required": true,
       "schema": { "enum": ["AU", "NZ"] }
     })
+  })
+
+  it('generates a valid openapi', async () => {
+    const swagger = generateSwagger(
+      {
+        get: {
+          '/': {
+            schema: {
+              request: {
+                query: s.object({
+                  region: s.enum({ values: ['AU', 'NZ']})
+                })
+              },
+              responses: {}
+            }
+          }
+        }
+      },
+      { openapi: '3.0.2', info: { title: "TEST API", version: 'x' } }
+    ) 
+    var validator = new OpenAPISchemaValidator({
+      version: 3
+    })
+    const result = validator.validate(swagger)
+    expect(result.errors).to.deep.equal([])
   })
 })

--- a/test/generate-swagger.test.js
+++ b/test/generate-swagger.test.js
@@ -471,7 +471,7 @@ describe('generateSwagger', () => {
           }
         }
       },
-      { openapi: '3.0.3', info: { title: 'TEST API', version: 'x' } }
+      { info: { title: 'TEST API', version: 'x' } }
     )
     var validator = new OpenAPISchemaValidator({
       version: '3.0.3'

--- a/test/generate-swagger.test.js
+++ b/test/generate-swagger.test.js
@@ -24,7 +24,7 @@ describe('generateSwagger', () => {
       {}
     )
 
-    expect(swagger.definitions).to.eql({
+    expect(swagger.components.schemas).to.eql({
       A: {
         properties: {
           id: {
@@ -38,12 +38,12 @@ describe('generateSwagger', () => {
     })
 
     expect(
-      swagger.paths['/']['get']['responses']['200']['schema']['properties']
+      swagger.paths['/']['get']['responses']['200']['content']['application/json']['schema']['properties']
     ).to.eql({
       x: {
         oneOf: [
           {
-            $ref: '#/definitions/A'
+            $ref: '#/components/schemas/A'
           },
           {
             properties: {
@@ -79,22 +79,22 @@ describe('generateSwagger', () => {
     )
 
     expect(
-      swagger.paths['/']['get']['responses']['200']['schema']['properties']
+      swagger.paths['/']['get']['responses']['200']['content']['application/json']['schema']['properties']
     ).to.eql({
       x: {
         oneOf: [
           {
-            $ref: '#/definitions/A'
+            $ref: '#/components/schemas/A'
           },
           {
-            $ref: '#/definitions/B'
+            $ref: '#/components/schemas/B'
           }
         ],
         type: 'object'
       }
     })
 
-    expect(swagger.definitions).to.eql({
+    expect(swagger.components.schemas).to.eql({
       A: {
         properties: {
           id: {
@@ -144,7 +144,7 @@ describe('generateSwagger', () => {
       {}
     )
 
-    expect(swagger.definitions).to.eql({
+    expect(swagger.components.schemas).to.eql({
       package: {
         properties: {
           id: {
@@ -153,7 +153,7 @@ describe('generateSwagger', () => {
           },
           rates: {
             items: {
-              $ref: '#/definitions/rate'
+              $ref: '#/components/schemas/rate'
             },
             type: 'array'
           }
@@ -173,7 +173,7 @@ describe('generateSwagger', () => {
       }
     })
 
-    expect(swagger.paths['/']['get']['responses']['200']).to.eql({
+    expect(swagger.paths['/']['get']['responses']['200']['content']['application/json']).to.eql({
       description: '200 response',
       schema: {
         properties: {
@@ -182,7 +182,7 @@ describe('generateSwagger', () => {
           },
           packages: {
             items: {
-              $ref: '#/definitions/package'
+              $ref: '#/components/schemas/package'
             },
             type: 'array'
           }
@@ -229,7 +229,7 @@ describe('generateSwagger', () => {
       {}
     )
 
-    expect(swagger.definitions).to.eql({
+    expect(swagger.components.schemas).to.eql({
       'rate': {
         'type': 'object',
         'properties': {
@@ -287,11 +287,10 @@ describe('generateSwagger', () => {
       }
     })
 
-    expect(swagger.paths['/']['get']['responses']['200']).to.eql({
+    expect(swagger.paths['/']['get']['responses']['200']['content']['application/json']).to.eql({
       'schema': {
         '$ref': '#/definitions/rate'
       },
-      'description': '200 response'
     })
   })
 })

--- a/test/generate-swagger.test.js
+++ b/test/generate-swagger.test.js
@@ -348,6 +348,20 @@ describe('generateSwagger', () => {
   })
 
   it('generates a valid openapi', async () => {
+    const rateSchema = s('rate', s.object({
+      id: s.uuid()
+    }))
+
+    const packageSchema = s(
+      'package',
+      s.object({ id: s.uuid(), rates: s.array({ of: rateSchema }) })
+    )
+
+    const okResponseSchema = s.object({
+      id: s.number(),
+      packages: s.array({ of: packageSchema })
+    })
+
     const swagger = generateSwagger(
       {
         get: {
@@ -355,10 +369,11 @@ describe('generateSwagger', () => {
             schema: {
               request: {
                 query: s.object({
+                  page: s.integer(),
                   region: s.enum({ values: ['AU', 'NZ']})
                 })
               },
-              responses: {}
+              responses: { 200: okResponseSchema }
             }
           }
         }
@@ -366,7 +381,7 @@ describe('generateSwagger', () => {
       { openapi: '3.0.3', info: { title: "TEST API", version: 'x' } }
     ) 
     var validator = new OpenAPISchemaValidator({
-      version: 3
+      version: '3.0.3'
     })
     const result = validator.validate(swagger)
     expect(result.errors).to.deep.equal([])

--- a/test/generate-swagger.test.js
+++ b/test/generate-swagger.test.js
@@ -363,7 +363,7 @@ describe('generateSwagger', () => {
           }
         }
       },
-      { openapi: '3.0.2', info: { title: "TEST API", version: 'x' } }
+      { openapi: '3.0.3', info: { title: "TEST API", version: 'x' } }
     ) 
     var validator = new OpenAPISchemaValidator({
       version: 3

--- a/test/generate-types.test.js
+++ b/test/generate-types.test.js
@@ -38,7 +38,7 @@ describe('generateTypes', () => {
         }
       },
       {
-        openapi: '3.0.2'
+        openapi: '3.0.3'
       }
     )
     const output = await generateServerTypes(swagger)

--- a/test/generate-types.test.js
+++ b/test/generate-types.test.js
@@ -37,9 +37,7 @@ describe('generateTypes', () => {
           }
         }
       },
-      {
-        openapi: '3.0.3'
-      }
+      {}
     )
     const output = await generateServerTypes(swagger)
 

--- a/test/generate-types.test.js
+++ b/test/generate-types.test.js
@@ -38,7 +38,7 @@ describe('generateTypes', () => {
         }
       },
       {
-        swagger: '2.0'
+        openapi: '3.0.2'
       }
     )
     const output = await generateServerTypes(swagger)
@@ -54,11 +54,17 @@ export interface paths {
   };
 }
 
-export interface definitions {
-  rate: {
-    id: string;
-    opt?: ("hotel_only" | "hotel_package") | ("hotel_only" | "hotel_package")[];
-    req: ("hotel_only" | "hotel_package") | ("hotel_only" | "hotel_package")[];
+export interface components {
+  schemas: {
+    rate: {
+      id: string;
+      opt?:
+        | ("hotel_only" | "hotel_package")
+        | ("hotel_only" | "hotel_package")[];
+      req:
+        | ("hotel_only" | "hotel_package")
+        | ("hotel_only" | "hotel_package")[];
+    };
   };
 }
 
@@ -73,7 +79,9 @@ export interface operations {
     responses: {
       /** 200 response */
       200: {
-        schema: definitions["rate"];
+        content: {
+          "application/json": definitions["rate"];
+        };
       };
     };
   };

--- a/test/integration/router.test.js
+++ b/test/integration/router.test.js
@@ -9,7 +9,7 @@ const { router, errorHandler, errors } = require('../../index')
 const uuid = require('../../lib/utils/uuid')
 
 const swaggerBaseProperties = {
-  swagger: '2.0',
+  openapi: '3',
   info: {
     description: 'This is my api',
     version: '1.0.0',
@@ -427,8 +427,8 @@ describe('router', () => {
     })
 
     it('should generate swagger', () => {
-      expect(routerInstance.toSwagger()).to.eql({
-        swagger: '2.0',
+      expect(routerInstance.toSwagger()).to.deep.equal({
+        openapi: '3',
         info: {
           description: 'This is my api',
           version: '1.0.0',
@@ -458,27 +458,31 @@ describe('router', () => {
               description: 'This route does something',
               responses: {
                 201: {
-                  schema: {
-                    type: 'object',
-                    properties: { id: { type: 'integer' } },
-                    required: ['id'],
-                    additionalProperties: false
+                  content: {
+                    'application/json': {
+                      schema: {
+                        type: 'object',
+                        properties: { id: { type: 'integer' } },
+                        required: ['id'],
+                        additionalProperties: false
+                      },
+                    }
                   },
                   description: '201 response'
                 }
               },
               parameters: [
-                { name: 'id', in: 'path', required: true, type: 'integer' },
+                { name: 'id', in: 'path', required: true, schema: { type: 'integer' } },
                 {
                   name: 'hello',
                   in: 'query',
                   required: true,
-                  type: 'string',
+                  schema: { type: 'string' },
                   description: 'Different ways to greet someone',
-                  enum: ['hi', 'hello']
+                  schema: { enum: ['hi', 'hello'], type: "string" }
                 },
-                { name: 'world', in: 'query', required: true, type: 'string' },
-                { name: 'foo', in: 'query', required: false, type: 'array', items: { 'type': 'string' } },
+                { name: 'world', in: 'query', required: true, schema: { type: 'string' } },
+                { name: 'foo', in: 'query', required: false,  schema: { type: 'array' }, items: { 'type': 'string' } },
                 {
                   name: 'payload',
                   in: 'body',

--- a/test/integration/router.test.js
+++ b/test/integration/router.test.js
@@ -482,7 +482,7 @@ describe('router', () => {
                   schema: { enum: ['hi', 'hello'], type: "string" }
                 },
                 { name: 'world', in: 'query', required: true, schema: { type: 'string' } },
-                { name: 'foo', in: 'query', required: false,  schema: { type: 'array' }, items: { 'type': 'string' } },
+                { name: 'foo', in: 'query', required: false,  schema: { type: 'array', items: { 'type': 'string' } } },
                 {
                   name: 'payload',
                   in: 'body',

--- a/test/integration/router.test.js
+++ b/test/integration/router.test.js
@@ -35,7 +35,7 @@ const swaggerBaseProperties = {
   ],
   paths: {},
   securityDefinitions: {},
-  definitions: {}
+  components: { schemas: {} }
 }
 
 const schema = {
@@ -495,7 +495,7 @@ describe('router', () => {
           }
         },
         securityDefinitions: {},
-        definitions: {}
+        components: { schemas: {} }
       })
     })
   })

--- a/test/integration/router.test.js
+++ b/test/integration/router.test.js
@@ -9,7 +9,7 @@ const { router, errorHandler, errors } = require('../../index')
 const uuid = require('../../lib/utils/uuid')
 
 const swaggerBaseProperties = {
-  openapi: '3.0.2',
+  openapi: '3.0.3',
   info: {
     description: 'This is my api',
     version: '1.0.0',
@@ -428,7 +428,7 @@ describe('router', () => {
 
     it('should generate swagger', () => {
       expect(routerInstance.toSwagger()).to.deep.equal({
-        openapi: '3.0.2',
+        openapi: '3.0.3',
         info: {
           description: 'This is my api',
           version: '1.0.0',

--- a/test/integration/router.test.js
+++ b/test/integration/router.test.js
@@ -9,7 +9,6 @@ const { router, errorHandler, errors } = require('../../index')
 const uuid = require('../../lib/utils/uuid')
 
 const swaggerBaseProperties = {
-  openapi: '3.0.3',
   info: {
     description: 'This is my api',
     version: '1.0.0',

--- a/test/integration/router.test.js
+++ b/test/integration/router.test.js
@@ -465,7 +465,7 @@ describe('router', () => {
                         properties: { id: { type: 'integer' } },
                         required: ['id'],
                         additionalProperties: false
-                      },
+                      }
                     }
                   },
                   description: '201 response'
@@ -477,9 +477,8 @@ describe('router', () => {
                   name: 'hello',
                   in: 'query',
                   required: true,
-                  schema: { type: 'string' },
                   description: 'Different ways to greet someone',
-                  schema: { enum: ['hi', 'hello'], type: "string" }
+                  schema: { enum: ['hi', 'hello'], type: 'string' }
                 },
                 { name: 'world', in: 'query', required: true, schema: { type: 'string', maxLength: 4, minLength: 2 } },
                 { name: 'foo', in: 'query', required: false, schema: { type: 'array', items: { 'type': 'string' } } },

--- a/test/integration/router.test.js
+++ b/test/integration/router.test.js
@@ -9,7 +9,7 @@ const { router, errorHandler, errors } = require('../../index')
 const uuid = require('../../lib/utils/uuid')
 
 const swaggerBaseProperties = {
-  openapi: '3',
+  openapi: '3.0.2',
   info: {
     description: 'This is my api',
     version: '1.0.0',
@@ -428,7 +428,7 @@ describe('router', () => {
 
     it('should generate swagger', () => {
       expect(routerInstance.toSwagger()).to.deep.equal({
-        openapi: '3',
+        openapi: '3.0.2',
         info: {
           description: 'This is my api',
           version: '1.0.0',

--- a/test/integration/router.test.js
+++ b/test/integration/router.test.js
@@ -481,8 +481,8 @@ describe('router', () => {
                   description: 'Different ways to greet someone',
                   schema: { enum: ['hi', 'hello'], type: "string" }
                 },
-                { name: 'world', in: 'query', required: true, schema: { type: 'string' } },
-                { name: 'foo', in: 'query', required: false,  schema: { type: 'array', items: { 'type': 'string' } } },
+                { name: 'world', in: 'query', required: true, schema: { type: 'string', maxLength: 4, minLength: 2 } },
+                { name: 'foo', in: 'query', required: false, schema: { type: 'array', items: { 'type': 'string' } } },
                 {
                   name: 'payload',
                   in: 'body',


### PR DESCRIPTION
## Why is this change happening?

OpenAPI v3 has been out for a long time now and we should support it as it has some new features like `oneOf`. When we want to improve the functionality of the OpenAPI generation its better if we can do so against v3 rather than doing it against v2 and then having to rework it later. There are some significant differences for things like query params.

## Summary of the change (from a product/customer perspective)

API Docs will be generated against v3 of the specification.
Auto generated types will have their "definitions" moved under "components".

## Summary of key technical changes

Relatively minor changes to meet the v3 spec. Some code could actually be deleted because the v3 spec is closer to JSON schema than v2. Added additional tests where the transformation need to change. Also introduced `openapi-schema-validator` as a dev dependency to validate the output.

One thing to note is that I've hardcoded application/json as the content type - hopefully this is OK but let me know if not.

## What have you done to test it?

I integrated it in to Public Offer locally, regenerated the types and loaded up the docs page in the browser.

Not sure why, but it already improved one of the types 🎉 

![Screen Shot 2021-11-27 at 3 42 05 pm](https://user-images.githubusercontent.com/633926/143668239-b183f2fd-b8b1-4f8a-b860-4a151f8146f4.png)

No other changes other than whitespace and definition->components was observed in the types generation.