### PR TITLE
Add definitions for hashmap

### DIFF
--- a/lib/generate-swagger.js
+++ b/lib/generate-swagger.js
@@ -86,6 +86,8 @@ const findNestedDefinition = (jsonSchema, definitions) => {
         $ref: `#/components/schemas/${name}`
       }
     })
+  } else if (!jsonSchema.properties && jsonSchema.additionalProperties) {
+    addDefinitions(definitions, jsonSchema.additionalProperties.name, jsonSchema.additionalProperties)
   } else {
     for (let key in jsonSchema.properties) {
       let property = jsonSchema.properties[key]

--- a/lib/generate-swagger.js
+++ b/lib/generate-swagger.js
@@ -86,8 +86,10 @@ const findNestedDefinition = (jsonSchema, definitions) => {
         $ref: `#/components/schemas/${name}`
       }
     })
-  } else if (!jsonSchema.properties && jsonSchema.additionalProperties) {
-    addDefinitions(definitions, jsonSchema.additionalProperties.name, jsonSchema.additionalProperties)
+  } else if (!jsonSchema.properties && jsonSchema.additionalProperties && jsonSchema.additionalProperties.name) {
+    const { name } = jsonSchema.additionalProperties
+    addDefinitions(definitions, name, jsonSchema.additionalProperties)
+    jsonSchema.additionalProperties = { $ref: `#/components/schemas/${name}` }
   } else {
     for (let key in jsonSchema.properties) {
       let property = jsonSchema.properties[key]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/router",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Wrapper around express router that provides validation and documentation out of the box",
   "main": "index.js",
   "types": "index.d.ts",

--- a/test/generate-swagger.test.js
+++ b/test/generate-swagger.test.js
@@ -36,6 +36,38 @@ const buildRouteDefinitions = ({ query, params, response }) =>
 const baseProperties = { info: { title: 'TEST API', version: 'x' } }
 
 describe('generateSwagger', () => {
+  it('creates definitions for hashmap', () => {
+    const response = s.hashmap(packageSchema)
+    const swagger = generateSwagger(buildRouteDefinitions({ response }), baseProperties)
+
+    expect(swagger.components.schemas).to.eql({
+      package: {
+        properties: {
+          id: {
+            format: 'uuid',
+            type: 'string'
+          },
+          rates: {
+            items: { $ref: '#/components/schemas/rate' },
+            type: 'array'
+          }
+        },
+        required: ['id', 'rates'],
+        type: 'object'
+      },
+      rate: {
+        properties: {
+          id: {
+            format: 'uuid',
+            type: 'string'
+          }
+        },
+        required: ['id'],
+        type: 'object'
+      }
+    })
+  })
+
   it('creates definitions for one of', () => {
     const response = s.object({ x: s.oneOf([hotelSchema, tourSchema]) })
     const swagger = generateSwagger(buildRouteDefinitions({ response }), baseProperties)


### PR DESCRIPTION
Before this change, we're not adding definitions for matchers that are used in hashmaps. Now we do.

Tested as well by running against the public offer schemas and observing only the expected differences.