### PR TITLE
Add handler type for autogenerated types

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Eventually we'll move this script in to this library and expose a CLI command so
 
 ### Add a script to your package.json
 
-```
+```json
 {
   "scripts": {
     "generate-types": "./src/scripts/generate-types.ts"
@@ -239,7 +239,7 @@ Now, anytime you run `yarn generate-types` the types will be regenerated for you
 
 For example:
 
-```
+```ts
 import { Handler } from '@luxuryescapes/router';
 import { operations } from '../../contract/server';
 

--- a/README.md
+++ b/README.md
@@ -206,11 +206,20 @@ TypeScript types.
 
 ### Create a helper file in your project
 
-See here for an example: https://github.com/lux-group/svc-public-offer/blob/master/src/script/generateTypes.ts
+```ts
+import { generateTypes } from "@luxuryescapes/router";
+import { mount } from "../routes";
+
+const generate = async () => {
+  await generateTypes(mount, "./src/contract");
+};
+
+generate().then(() => process.exit(0));
+```
 
 `mount` is a function that takes an Express server and returns a RouterAbstraction. In short, it's a function that uses @luxuryescapes/router to set up your endpoints.
 
-Eventually this step will not be required. See https://aussiecommerce.atlassian.net/browse/ENGX-249
+Eventually we'll move this script in to this library and expose a CLI command so this step will not be required.
 
 ### Add a script to your package.json
 

--- a/README.md
+++ b/README.md
@@ -204,20 +204,15 @@ If you want the raw swagger json definition you can use `toSwagger`
 If you use Strummer schemas to validate your endpoints, you can use the following steps to auto-generate
 TypeScript types.
 
-## Create a helper file in your project
+### Create a helper file in your project
 
-```
-import { generateTypes } from "@luxuryescapes/router";
-import { mount } from "../routes";
-
-generateTypes(mount, "./src/contract");
-
-process.exit(0);
-```
+See here for an example: https://github.com/lux-group/svc-public-offer/blob/master/src/script/generateTypes.ts
 
 `mount` is a function that takes an Express server and returns a RouterAbstraction. In short, it's a function that uses @luxuryescapes/router to set up your endpoints.
 
-## Add a script to your package.json
+Eventually this step will not be required. See https://aussiecommerce.atlassian.net/browse/ENGX-249
+
+### Add a script to your package.json
 
 ```
 {
@@ -229,9 +224,20 @@ process.exit(0);
 
 Where the path is to the file you just created.
 
-## Profit
+### Profit
 
 Now, anytime you run `yarn generate-types` the types will be regenerated for you to use in your controllers.
+
+For example:
+
+```
+import { Handler } from '@luxuryescapes/router';
+import { operations } from '../../contract/server';
+
+export const index: Handler<operations, 'exampleIndex'> = (req, res) => {
+  res.json({ hello: 'world' });
+};
+```
 
 ## Upgrade Guides
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/router",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Wrapper around express router that provides validation and documentation out of the box",
   "main": "index.js",
   "types": "index.d.ts",

--- a/test/generate-types.test.js
+++ b/test/generate-types.test.js
@@ -55,6 +55,7 @@ export interface paths {
 export interface components {
   schemas: {
     rate: {
+      /** Format: uuid */
       id: string;
       opt?:
         | ("hotel_only" | "hotel_package")


### PR DESCRIPTION
From https://github.com/lux-group/svc-public-offer/blob/master/src/api/common/types.ts

A helper type that allows you to type your Express handler functions according to the autogenerated types.

An example can be seen here: https://github.com/lux-group/svc-public-offer/blob/master/src/api/v2/controllers/offer.ts#L70