### PR TITLE
Add generateTypes CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,43 +201,22 @@ If you want the raw swagger json definition you can use `toSwagger`
 
 ## TypeScript
 
-If you use Strummer schemas to validate your endpoints, you can use the following steps to auto-generate
+If you use Strummer schemas to validate your endpoints, you can use the generateTypes CLI command to auto-generate
 TypeScript types.
 
-### Create a helper file in your project
+For example if your router was in src/router.ts, and you wanted to output the contract to src/api/contract/server.ts, you would do:
 
-```ts
-import { generateTypes } from "@luxuryescapes/router";
-import { mount } from "../routes";
-
-const generate = async () => {
-  await generateTypes(mount, "./src/contract");
-};
-
-generate().then(() => process.exit(0));
+```bash
+yarn generateTypes src/router.ts src/api/contract/server.ts
 ```
 
-`mount` is a function that takes an Express server and returns a RouterAbstraction. In short, it's a function that uses @luxuryescapes/router to set up your endpoints.
-
-Eventually we'll move this script in to this library and expose a CLI command so this step will not be required.
-
-### Add a script to your package.json
-
-```json
-{
-  "scripts": {
-    "generate-types": "./src/scripts/generate-types.ts"
-  }
-}
-```
-
-Where the path is to the file you just created.
+Your router file must export a `mount` function that takes an Express server and returns a RouterAbstraction. In short, it's a function that uses @luxuryescapes/router to set up your endpoints.
 
 ### Profit
 
-Now, anytime you run `yarn generate-types` the types will be regenerated for you to use in your controllers.
+Now, anytime you run `yarn generateTypes` the types will be regenerated for you to use in your controllers.
 
-For example:
+An example of the contract usage is:
 
 ```ts
 import { Handler } from '@luxuryescapes/router';

--- a/generate-types.js
+++ b/generate-types.js
@@ -8,7 +8,9 @@ const { generateTypes } = require('./index')
 
 const routerPath = process.argv[2]
 if (!routerPath) throw new Error('Usage: yarn generateTypes <path-to-router> <path-to-contract>')
+
 const contractPath = process.argv[3]
+if (!contractPath) throw new Error('Usage: yarn generateTypes <path-to-router> <path-to-contract>')
 
 const { mount } = require(process.cwd() + '/' + routerPath)
 

--- a/generate-types.js
+++ b/generate-types.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+require('ts-node').register({ transpileOnly: true })
+
+const { promisify } = require('util')
+const { exec } = require('child_process')
+const { generateTypes } = require('./index')
+
+const routerPath = process.argv[2]
+if (!routerPath) throw new Error('Usage: yarn generateTypes <path-to-router> <path-to-contract>')
+const contractPath = process.argv[3]
+
+const { mount } = require(process.cwd() + '/' + routerPath)
+
+async function generate () {
+  await generateTypes(mount, process.cwd() + '/' + contractPath)
+
+  const { stdout } = await promisify(exec)(`git diff ${contractPath}`)
+
+  const pendingCommits = !!stdout
+
+  if (pendingCommits) {
+    console.log('Types has changed since the last commit.')
+    console.log(stdout)
+  } else {
+    console.log('No changes.')
+  }
+
+  return !!pendingCommits
+}
+
+generate()
+  .then((pendingCommits) => {
+    const exitCode = process.argv[2] === 'ci' && pendingCommits ? 1 : 0
+    process.exit(exitCode)
+  })
+  .catch((e) => {
+    console.error(e)
+    process.exit(1)
+  })

--- a/lib/generate-types.js
+++ b/lib/generate-types.js
@@ -12,7 +12,7 @@ const generateTypes = async (mount, path) => {
   const output = await generateServerTypes(openApiSpec)
   if (process.env.DEBUG) console.log(output)
 
-  writeFileSync(`${path}/server.ts`, output)
+  writeFileSync(path, output)
 }
 
 module.exports = generateTypes

--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
   "name": "@luxuryescapes/router",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Wrapper around express router that provides validation and documentation out of the box",
   "main": "index.js",
   "types": "index.d.ts",
+  "bin": {
+    "generateTypes": "generate-types.js"
+  },
   "scripts": {
     "test": "mocha --recursive",
     "lint": "standard | snazzy"


### PR DESCRIPTION
This removes the need for boilerplate code in the services to hook up the generateTypes functionality.

Kudos to @alecluxuryescapes for the push to get this over the line.

See README for further info.