### PR TITLE
Fix generateTypes ci option

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,14 +205,14 @@ TypeScript types.
 For example if your router was in src/router.ts, and you wanted to output the contract to src/api/contract/server.ts, you would do:
 
 ```bash
-yarn router:generateTypes src/router.ts src/api/contract/server.ts
+yarn routerGenerateTypes src/router.ts src/api/contract/server.ts
 ```
 
 Your router file must export a `mount` function that takes an Express server and returns a RouterAbstraction. In short, it's a function that uses @luxuryescapes/router to set up your endpoints.
 
 ### Profit
 
-Now, anytime you run `yarn router:generateTypes` the types will be regenerated for you to use in your controllers.
+Now, anytime you run `yarn routerGenerateTypes` the types will be regenerated for you to use in your controllers.
 
 An example of the contract usage is:
 

--- a/README.md
+++ b/README.md
@@ -16,14 +16,12 @@ Opinionated wrapper around express, which adds in validation via [strummer](http
 
 ```
 npm install @luxuryescapes/router
-npm install @sentry/node # optional for Sentry support
 ```
 
 or
 
 ```
 yarn add @luxuryescapes/router
-yarn add @sentry/node # optional for Sentry support
 ```
 
 ```js
@@ -207,14 +205,14 @@ TypeScript types.
 For example if your router was in src/router.ts, and you wanted to output the contract to src/api/contract/server.ts, you would do:
 
 ```bash
-yarn generateTypes src/router.ts src/api/contract/server.ts
+yarn router:generateTypes src/router.ts src/api/contract/server.ts
 ```
 
 Your router file must export a `mount` function that takes an Express server and returns a RouterAbstraction. In short, it's a function that uses @luxuryescapes/router to set up your endpoints.
 
 ### Profit
 
-Now, anytime you run `yarn generateTypes` the types will be regenerated for you to use in your controllers.
+Now, anytime you run `yarn router:generateTypes` the types will be regenerated for you to use in your controllers.
 
 An example of the contract usage is:
 

--- a/generate-types.js
+++ b/generate-types.js
@@ -33,7 +33,7 @@ async function generate () {
 
 generate()
   .then((pendingCommits) => {
-    const exitCode = process.argv[2] === 'ci' && pendingCommits ? 1 : 0
+    const exitCode = process.argv[4] === '--ci' && pendingCommits ? 1 : 0
     process.exit(exitCode)
   })
   .catch((e) => {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "types": "index.d.ts",
   "bin": {
-    "router:generateTypes": "generate-types.js"
+    "routerGenerateTypes": "generate-types.js"
   },
   "scripts": {
     "test": "mocha --recursive",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "types": "index.d.ts",
   "bin": {
-    "generateTypes": "generate-types.js"
+    "router:generateTypes": "generate-types.js"
   },
   "scripts": {
     "test": "mocha --recursive",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/router",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Wrapper around express router that provides validation and documentation out of the box",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
* Change `yarn generateTypes` to be `yarn router:generateTypes` so that projects can implement their own `yarn generateTypes`
* Fixes the `ci` option.