### PR TITLE
Handle syntax errors when generating types

### DIFF
--- a/generate-types.js
+++ b/generate-types.js
@@ -30,6 +30,10 @@ const getMount = () => {
     if (e.code === 'MODULE_NOT_FOUND') {
       exit(`Error: Could not find router at ${process.cwd() + '/' + routerPath}`)
     }
+    if (e instanceof ReferenceError) {
+      console.error(e)
+      exit(`Error: Could not generate types due to syntax issues.`)
+    }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/router",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Wrapper around express router that provides validation and documentation out of the box",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
This handles the case where there is a JS error in your code and you try to generate types. The process is already resilient to TypeScript type errors.