### PR TITLE
Include in usage optional auto increment of package

### DIFF
--- a/generate-types.js
+++ b/generate-types.js
@@ -23,12 +23,6 @@ if (!contractPath) {
 
 const isCI = process.argv[4] === '--ci'
 
-const readline = require('readline')
-const rl = readline.createInterface({
-  input: process.stdin,
-  output: process.stdout
-})
-
 const getMount = () => {
   try {
     const { mount } = require(process.cwd() + '/' + routerPath)
@@ -63,15 +57,10 @@ async function generate () {
     const contractDirectoryPath = contractPath.substring(0, contractPath.lastIndexOf('/'))
 
     var pjson = require(process.cwd() + '/' + contractDirectoryPath + '/package.json')
-    const response = await new Promise(resolve => {
-      rl.question(`Currrent contract version is ${pjson.version} - Do you want to increment the version ?  (Y/n)`, resolve)
-    })
-    rl.close()
-    if (!response || response === 'y' || response === 'Y') {
-      console.log('Attempting to increment package version.')
-      const result = await promisify(exec)(`npm --prefix ${contractDirectoryPath} --no-git-tag-version version patch`)
-      console.log('Package version incremented to ' + result.stdout)
-    }
+
+    console.log(`Currrent contract version is ${pjson.version}. Attempting to increment package version.`)
+    const result = await promisify(exec)(`npm --prefix ${contractDirectoryPath} --no-git-tag-version version patch`)
+    console.log('Package version incremented to ' + result.stdout)
   } else {
     console.log('No changes.')
   }

--- a/generate-types.js
+++ b/generate-types.js
@@ -13,16 +13,22 @@ const exit = (message) => {
 
 const routerPath = process.argv[2]
 if (!routerPath) {
-  exit('Usage: yarn generateTypes <path-to-router> <path-to-contract> [<should-increment-version>] [<path-to-contract-directory>]')
+  exit('Usage: yarn generateTypes <path-to-router> <path-to-contract> [<path-to-contract-directory>]')
 }
 
 const contractPath = process.argv[3]
 if (!contractPath) {
-  exit('Usage: yarn generateTypes <path-to-router> <path-to-contract> [<should-increment-version>] [<path-to-contract-directory>]')
+  exit('Usage: yarn generateTypes <path-to-router> <path-to-contract> [<path-to-contract-directory>]')
 }
 
-const shouldIncrementVersion = process.argv[4]
-let contractDirectoryPath = process.argv[5]
+let contractDirectoryPath = process.argv[4]
+
+const readline = require('readline');
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout
+});
+
 
 const getMount = () => {
   try {
@@ -51,19 +57,23 @@ async function generate () {
 
   if (pendingCommits) {
     console.log('Types have changed since the last commit.')
-    if (shouldIncrementVersion) {
+    console.log(stdout)
+
+    if (!contractDirectoryPath) {
+      contractDirectoryPath = contractPath.substring(0, contractPath.lastIndexOf("/"));
+      console.log(`path-to-contract-directory not set, resolving to parent folder of contract: ${contractDirectoryPath}`)
+    }
+
+    var pjson = require(process.cwd() + '/' + contractDirectoryPath + '/package.json');
+    const response = await new Promise(resolve => {
+      rl.question(`Currrent contract version is ${pjson.version} - Do you want to increment the version ?  (Y/n)`, resolve)
+    })
+    rl.close()
+    if(!response || response == 'y' || response == 'Y') {
       console.log('Attempting to increment package version.')
-      if (!contractDirectoryPath) {
-        contractDirectoryPath = contractPath.substring(0, contractPath.lastIndexOf("/"));
-        console.log(`path-to-contract-directory not set, resolving to parent folder of contract: ${contractDirectoryPath}`)
-      }
       const result = await promisify(exec)(`npm --prefix ${contractDirectoryPath} --no-git-tag-version version patch`)
       console.log('Package version incremented to ' + result.stdout)
-    } else {
-      console.log('Please increment your contract package version.')
     }
-    
-    console.log(stdout)
   } else {
     console.log('No changes.')
   }

--- a/generate-types.js
+++ b/generate-types.js
@@ -13,13 +13,16 @@ const exit = (message) => {
 
 const routerPath = process.argv[2]
 if (!routerPath) {
-  exit('Usage: yarn generateTypes <path-to-router> <path-to-contract>')
+  exit('Usage: yarn generateTypes <path-to-router> <path-to-contract> [<should-increment-version>] [<path-to-contract-directory>]')
 }
 
 const contractPath = process.argv[3]
 if (!contractPath) {
-  exit('Usage: yarn generateTypes <path-to-router> <path-to-contract>')
+  exit('Usage: yarn generateTypes <path-to-router> <path-to-contract> [<should-increment-version>] [<path-to-contract-directory>]')
 }
+
+const shouldIncrementVersion = process.argv[4]
+let contractDirectoryPath = process.argv[5]
 
 const getMount = () => {
   try {
@@ -47,11 +50,24 @@ async function generate () {
   const pendingCommits = !!stdout
 
   if (pendingCommits) {
-    console.log('Types has changed since the last commit.')
+    console.log('Types have changed since the last commit.')
+    if (shouldIncrementVersion) {
+      console.log('Attempting to increment package version.')
+      if (!contractDirectoryPath) {
+        contractDirectoryPath = contractPath.substring(0, contractPath.lastIndexOf("/"));
+        console.log(`path-to-contract-directory not set, resolving to parent folder of contract: ${contractDirectoryPath}`)
+      }
+      const result = await promisify(exec)(`npm --prefix ${contractDirectoryPath} --no-git-tag-version version patch`)
+      console.log('Package version incremented to ' + result.stdout)
+    } else {
+      console.log('Please increment your contract package version.')
+    }
+    
     console.log(stdout)
   } else {
     console.log('No changes.')
   }
+
 
   return !!pendingCommits
 }

--- a/generate-types.js
+++ b/generate-types.js
@@ -23,12 +23,11 @@ if (!contractPath) {
 
 const isCI = process.argv[4] === '--ci'
 
-const readline = require('readline');
+const readline = require('readline')
 const rl = readline.createInterface({
   input: process.stdin,
   output: process.stdout
-});
-
+})
 
 const getMount = () => {
   try {
@@ -58,17 +57,17 @@ async function generate () {
   if (pendingCommits) {
     console.log('Types have changed since the last commit.')
     console.log(stdout)
-    
-    if(isCI) return;
 
-    const contractDirectoryPath = contractPath.substring(0, contractPath.lastIndexOf("/"));
+    if (isCI) return
 
-    var pjson = require(process.cwd() + '/' + contractDirectoryPath + '/package.json');
+    const contractDirectoryPath = contractPath.substring(0, contractPath.lastIndexOf('/'))
+
+    var pjson = require(process.cwd() + '/' + contractDirectoryPath + '/package.json')
     const response = await new Promise(resolve => {
       rl.question(`Currrent contract version is ${pjson.version} - Do you want to increment the version ?  (Y/n)`, resolve)
     })
     rl.close()
-    if(!response || response == 'y' || response == 'Y') {
+    if (!response || response === 'y' || response === 'Y') {
       console.log('Attempting to increment package version.')
       const result = await promisify(exec)(`npm --prefix ${contractDirectoryPath} --no-git-tag-version version patch`)
       console.log('Package version incremented to ' + result.stdout)
@@ -76,7 +75,6 @@ async function generate () {
   } else {
     console.log('No changes.')
   }
-
 
   return !!pendingCommits
 }

--- a/generate-types.js
+++ b/generate-types.js
@@ -13,15 +13,15 @@ const exit = (message) => {
 
 const routerPath = process.argv[2]
 if (!routerPath) {
-  exit('Usage: yarn generateTypes <path-to-router> <path-to-contract> [<path-to-contract-directory>]')
+  exit('Usage: yarn generateTypes <path-to-router> <path-to-contract>')
 }
 
 const contractPath = process.argv[3]
 if (!contractPath) {
-  exit('Usage: yarn generateTypes <path-to-router> <path-to-contract> [<path-to-contract-directory>]')
+  exit('Usage: yarn generateTypes <path-to-router> <path-to-contract>')
 }
 
-let contractDirectoryPath = process.argv[4]
+const isCI = process.argv[4] === '--ci'
 
 const readline = require('readline');
 const rl = readline.createInterface({
@@ -58,11 +58,10 @@ async function generate () {
   if (pendingCommits) {
     console.log('Types have changed since the last commit.')
     console.log(stdout)
+    
+    if(isCI) return;
 
-    if (!contractDirectoryPath) {
-      contractDirectoryPath = contractPath.substring(0, contractPath.lastIndexOf("/"));
-      console.log(`path-to-contract-directory not set, resolving to parent folder of contract: ${contractDirectoryPath}`)
-    }
+    const contractDirectoryPath = contractPath.substring(0, contractPath.lastIndexOf("/"));
 
     var pjson = require(process.cwd() + '/' + contractDirectoryPath + '/package.json');
     const response = await new Promise(resolve => {
@@ -84,7 +83,7 @@ async function generate () {
 
 generate()
   .then((pendingCommits) => {
-    const exitCode = process.argv[4] === '--ci' && pendingCommits ? 1 : 0
+    const exitCode = isCI && pendingCommits ? 1 : 0
     process.exit(exitCode)
   })
   .catch((e) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/router",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "description": "Wrapper around express router that provides validation and documentation out of the box",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
When generating types, often the user would want the package to auto increment. This changes increments the package.json if the types have changed.

In the case of CI, incrementing is disabled.