### PR TITLE
When handler params are not defined, it should give the empty object

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -168,17 +168,17 @@ declare module "@luxuryescapes/router" {
     parameters = operations[O]["parameters"],
     PathParams = parameters extends { path: any }
       ? parameters["path"]
-      : Record<string, never>,
+      : {},
     ReqBody = parameters extends { body: { payload: any } }
       ? parameters["body"]["payload"]
-      : Record<string, never>,
+      : {},
     Query = parameters extends { query: any }
       ? parameters["query"]
-      : Record<string, never>,
-    header = parameters extends { header: any } ?
-      parameters['header']:
-      Record<string, never>,
-    Request = header extends { Cookie: any } ?
+      : {},
+    Header = parameters extends { header: any }
+      ? parameters['header']
+      : {},
+    Request = Header extends { Cookie: any } ?
       AuthenticatedRequest<PathParams, R, ReqBody, Query> :
       ExpressRequest<PathParams, R, ReqBody, Query>
   > {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/router",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "description": "Wrapper around express router that provides validation and documentation out of the box",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
I noticed that if you forget to specific a path param in the Strummer schema, it appears in the Controller as `never`. And it turns out you can pass `never` to functions and TypeScript doesn't complain!

Before:

![Screen Shot 2022-02-16 at 1 30 47 pm](https://user-images.githubusercontent.com/633926/154185046-12578c11-8e79-4ff9-a897-21b79b417e80.png)

After:

![Screen Shot 2022-02-16 at 1 30 18 pm](https://user-images.githubusercontent.com/633926/154185011-774995ae-d7fb-4333-bc92-cddc6e2751fa.png)

