### PR TITLE
Use omit instead of mutating

### DIFF
--- a/lib/generate-swagger.js
+++ b/lib/generate-swagger.js
@@ -1,3 +1,5 @@
+const omit = require('lodash.omit')
+
 const jsonSchemaToParameters = (schema, { into }) => {
   if (!schema.properties) {
     return []
@@ -8,11 +10,10 @@ const jsonSchemaToParameters = (schema, { into }) => {
       name: property,
       in: into,
       required: schema.required ? schema.required.includes(property) : false,
-      schema: schemaProperty
+      schema: omit(schemaProperty, ['description'])
     }
     if (schemaProperty.description) {
       result.description = schemaProperty.description
-      delete schemaProperty.description
     }
     return result
   })
@@ -114,9 +115,8 @@ const findNestedDefinition = (jsonSchema, definitions) => {
 
 const addDefinitions = (definitions, name, jsonSchema) => {
   if (!definitions[name]) {
-    delete jsonSchema.name
     findNestedDefinition(jsonSchema, definitions)
-    definitions[name] = jsonSchema
+    definitions[name] = omit(jsonSchema, ['name'])
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@types/node": "^17.0.8",
     "express": "^4.17.1",
     "jest": "^27.5.1",
+    "lodash.omit": "^4.5.0",
     "openapi-schema-validator": "^9.3.1",
     "qs": "^6.10.3",
     "snazzy": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/router",
-  "version": "2.5.8",
+  "version": "2.5.9",
   "description": "Wrapper around express router that provides validation and documentation out of the box",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@types/node": "^17.0.8",
     "express": "^4.17.1",
     "jest": "^27.5.1",
-    "lodash.omit": "^4.5.0",
     "openapi-schema-validator": "^9.3.1",
     "qs": "^6.10.3",
     "snazzy": "^8.0.0",
@@ -42,6 +41,7 @@
   "dependencies": {
     "@luxuryescapes/strummer": "^2.11.3",
     "@sentry/node": "^6.17.4",
+    "lodash.omit": "^4.5.0",
     "openapi-typescript": "^4.4.0",
     "swagger-ui-express": "^4.0.6"
   },

--- a/test/integration/__snapshots__/router.test.js.snap
+++ b/test/integration/__snapshots__/router.test.js.snap
@@ -4,7 +4,32 @@ exports[`router toSwagger should generate swagger 1`] = `
 Object {
   "basePath": "/",
   "components": Object {
-    "schemas": Object {},
+    "schemas": Object {
+      "itemA": Object {
+        "additionalProperties": false,
+        "properties": Object {
+          "id": Object {
+            "type": "integer",
+          },
+        },
+        "required": Array [
+          "id",
+        ],
+        "type": "object",
+      },
+      "itemB": Object {
+        "additionalProperties": false,
+        "properties": Object {
+          "id": Object {
+            "type": "integer",
+          },
+        },
+        "required": Array [
+          "id",
+        ],
+        "type": "object",
+      },
+    },
   },
   "consumes": Array [
     "application/json",
@@ -103,6 +128,17 @@ Object {
                   "properties": Object {
                     "id": Object {
                       "type": "integer",
+                    },
+                    "item": Object {
+                      "oneOf": Array [
+                        Object {
+                          "$ref": "#/components/schemas/itemA",
+                        },
+                        Object {
+                          "$ref": "#/components/schemas/itemB",
+                        },
+                      ],
+                      "type": "object",
                     },
                   },
                   "required": Array [

--- a/test/integration/router.test.js
+++ b/test/integration/router.test.js
@@ -59,7 +59,13 @@ const schema = {
   },
   responses: {
     201: s.objectWithOnly({
-      id: s.integer()
+      id: s.integer(),
+      item: s.optional(
+        s.oneOf([
+          s('itemA', s.objectWithOnly({ id: s.integer() })),
+          s('itemB', s.objectWithOnly({ id: s.integer() }))
+        ])
+      )
     })
   }
 }
@@ -88,7 +94,7 @@ describe('router', () => {
     res.status(200).json({ body: req.body })
   }
 
-  const setupRoutes = async ({ handler, opts, routeOpts = {} } = {}) => {
+  const setupRoutes = ({ handler, opts, routeOpts = {} } = {}) => {
     routerInstance = router(server, {
       validateResponses: true,
       swaggerBaseProperties,
@@ -479,12 +485,15 @@ describe('router', () => {
   })
 
   describe('toSwagger', () => {
-    beforeEach(async () => {
-      return setupRoutes()
-    })
+    beforeEach(setupRoutes)
 
     it('should generate swagger', () => {
       expect(routerInstance.toSwagger()).toMatchSnapshot()
+    })
+
+    it('includes the components', () => {
+      const swagger = routerInstance.toSwagger()
+      expect(Object.keys(swagger.components.schemas)).toEqual(['itemA', 'itemB'])
     })
   })
 


### PR DESCRIPTION
Mutating the data means that if you run generateSwagger again, you get a different result. Very tricky bug!

Use `omit` instead. We could write our own rather than using Lodash's. No strong opinions here. If this was TypeScript I'd recommend using Lodash so that we get the right type behaviour, but since this is JS 🤷 