### PR TITLE
feat(types): handle null or string type

### DIFF
--- a/lib/generate-server-types.js
+++ b/lib/generate-server-types.js
@@ -1,0 +1,12 @@
+const generateTypes = require('openapi-typescript').default
+
+const generateServerTypes = async (openApiSpec) => generateTypes(openApiSpec, {
+  formatter (node) {
+    // This handles the custom NullOrString matcher that is defined in some services
+    if (Array.isArray(node.type) && node.type[0] === 'null' && node.type[1] === 'string') {
+      return 'null | string'
+    }
+  }
+})
+
+module.exports = generateServerTypes

--- a/lib/generate-server-types.js
+++ b/lib/generate-server-types.js
@@ -3,7 +3,14 @@ const generateTypes = require('openapi-typescript').default
 const generateServerTypes = async (openApiSpec) => generateTypes(openApiSpec, {
   formatter (node) {
     // This handles the custom NullOrString matcher that is defined in some services
-    if (Array.isArray(node.type) && node.type[0] === 'null' && node.type[1] === 'string') {
+    if (
+      Array.isArray(node.type) &&
+      node.type.length === 2 &&
+      (
+        (node.type[0] === 'null' && node.type[1] === 'string') ||
+        (node.type[0] === 'string' && node.type[1] === 'null')
+      )
+    ) {
       return 'null | string'
     }
   }

--- a/lib/generate-types.js
+++ b/lib/generate-types.js
@@ -1,6 +1,6 @@
 const { writeFileSync } = require('fs')
 const express = require('express')
-const generateServerTypes = require('openapi-typescript').default
+const generateServerTypes = require('./generate-server-types')
 
 const generateTypes = async (mount, path) => {
   const server = express()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/router",
-  "version": "2.5.10",
+  "version": "2.5.11",
   "description": "Wrapper around express router that provides validation and documentation out of the box",
   "main": "index.js",
   "types": "index.d.ts",

--- a/test/generate-types.test.js
+++ b/test/generate-types.test.js
@@ -1,11 +1,26 @@
 const s = require('@luxuryescapes/strummer')
 const generateSwagger = require('../lib/generate-swagger')
-const generateServerTypes = require('openapi-typescript').default
+const generateServerTypes = require('../lib/generate-server-types')
+
+const nullOrString = () =>
+  s.createMatcher({
+    initialize: function () {
+      this.matcher = s.string()
+    },
+    match: function (path, value) {
+      if (value === null && typeof value === 'object') return
+      return this.matcher.match(path, value)
+    },
+    toJSONSchema: function () {
+      return { type: ['null', 'string'] }
+    }
+  })()
 
 describe('generateTypes', () => {
   it('creates definitions for deep options', async () => {
     const rateSchema = s('rate', s.object({
       id: s.uuid(),
+      comment: nullOrString(),
       opt: s.optional(
         s.oneOf([
           s.enum({ values: ['hotel_only', 'hotel_package'], type: 'string' }),
@@ -56,6 +71,7 @@ export interface components {
     rate: {
       /** Format: uuid */
       id: string;
+      comment: null | string;
       opt?:
         | ("hotel_only" | "hotel_package")
         | ("hotel_only" | "hotel_package")[];

--- a/test/generate-types.test.js
+++ b/test/generate-types.test.js
@@ -16,11 +16,26 @@ const nullOrString = () =>
     }
   })()
 
+const stringOrNull = () =>
+  s.createMatcher({
+    initialize: function () {
+      this.matcher = s.string()
+    },
+    match: function (path, value) {
+      if (value === null && typeof value === 'object') return
+      return this.matcher.match(path, value)
+    },
+    toJSONSchema: function () {
+      return { type: ['string', 'null'] }
+    }
+  })()
+
 describe('generateTypes', () => {
   it('creates definitions for deep options', async () => {
     const rateSchema = s('rate', s.object({
       id: s.uuid(),
       comment: nullOrString(),
+      description: stringOrNull(),
       opt: s.optional(
         s.oneOf([
           s.enum({ values: ['hotel_only', 'hotel_package'], type: 'string' }),
@@ -72,6 +87,7 @@ export interface components {
       /** Format: uuid */
       id: string;
       comment: null | string;
+      description: null | string;
       opt?:
         | ("hotel_only" | "hotel_package")
         | ("hotel_only" | "hotel_package")[];


### PR DESCRIPTION
This will allow us to generate the correct type for a custom matcher that we have in one of our services

Currently the json schema of the matcher looks like

```
{
  type: ["null", "string"]
}
```

(and is totally valid json schema apparently see [this section](https://json-schema.org/draft/2020-12/json-schema-core.html#rfc.section.7.6.1))

and it needs to stay this way as Admin Portal uses this to auto generate html forms

which gets generated as `fieldName: unknown` when running `generateTypes` but we should expect to see `fieldName: null | string`

although it would be nice if this code got passed in from the external codebase into router, it seems non trivial to do so seeing as though we are using the generate types task as a cli command, we would have to essentially eval some javascript passed in which seems not pleasant (unless someone could think of a better way)

I made the custom formatter so specific that I don't see it causing a problem to any other schemas we have