### PR TITLE
fix(server-types): fix ci option for checking whether there are type changes

### DIFF
--- a/generate-types.js
+++ b/generate-types.js
@@ -49,7 +49,7 @@ async function generate () {
     console.log('Types have changed since the last commit.')
     console.log(stdout)
 
-    if (isCI) return
+    if (isCI) return true
 
     const contractDirectoryPath = contractPath.substring(0, contractPath.lastIndexOf('/'))
 
@@ -62,13 +62,16 @@ async function generate () {
     console.log('No changes.')
   }
 
-  return !!pendingCommits
+  return pendingCommits
 }
 
 generate()
   .then((pendingCommits) => {
-    const exitCode = isCI && pendingCommits ? 1 : 0
-    process.exit(exitCode)
+    if (pendingCommits && isCI) {
+      console.error('Types have changed since the last commit. Please regenerate your types and commit the changes')
+      process.exit(1)
+    }
+    process.exit(0)
   })
   .catch((e) => {
     console.error(e)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/router",
-  "version": "2.5.11",
+  "version": "2.5.12",
   "description": "Wrapper around express router that provides validation and documentation out of the box",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Noticed that CI was not failing when changes to the contract had not been committed

It was because we were not returning whether there are `pendingCommits` when it's in CI mode