### PR TITLE
silence no sentry log info for tests

### DIFF
--- a/lib/sentry.js
+++ b/lib/sentry.js
@@ -13,13 +13,14 @@ let initialized = false
 const initialize = (opts) => {
   const logger = opts.logger || console
   const appEnv = opts.appEnv || 'unknown'
+  const production = appEnv === 'production'
 
-  if (!Sentry) {
+  if (!Sentry && production) {
     logger.warn('Sentry is not installed, skipping initialization.')
     return initialized
   }
 
-  if (!opts.sentryDSN) {
+  if (!opts.sentryDSN && production) {
     logger.warn('No Sentry DSN configured, skipping initialization.')
     return initialized
   }

--- a/lib/sentry.js
+++ b/lib/sentry.js
@@ -15,13 +15,17 @@ const initialize = (opts) => {
   const appEnv = opts.appEnv || 'unknown'
   const initializationSkipWarn = ['production', 'unknown'].includes(appEnv)
 
-  if (!Sentry && initializationSkipWarn) {
-    logger.warn('Sentry is not installed, skipping initialization.')
+  if (!Sentry) {
+    if (initializationSkipWarn) {
+      logger.warn('Sentry is not installed, skipping initialization.')
+    }
     return initialized
   }
 
-  if (!opts.sentryDSN && initializationSkipWarn) {
-    logger.warn('No Sentry DSN configured, skipping initialization.')
+  if (!opts.sentryDSN) {
+    if (initializationSkipWarn) {
+      logger.warn('No Sentry DSN configured, skipping initialization.')
+    }
     return initialized
   }
 

--- a/lib/sentry.js
+++ b/lib/sentry.js
@@ -13,14 +13,14 @@ let initialized = false
 const initialize = (opts) => {
   const logger = opts.logger || console
   const appEnv = opts.appEnv || 'unknown'
-  const production = appEnv === 'production'
+  const initializationSkipWarn = ['production', 'unknown'].includes(appEnv)
 
-  if (!Sentry && production) {
+  if (!Sentry && initializationSkipWarn) {
     logger.warn('Sentry is not installed, skipping initialization.')
     return initialized
   }
 
-  if (!opts.sentryDSN && production) {
+  if (!opts.sentryDSN && initializationSkipWarn) {
     logger.warn('No Sentry DSN configured, skipping initialization.')
     return initialized
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/router",
-  "version": "2.5.13",
+  "version": "2.5.14",
   "description": "Wrapper around express router that provides validation and documentation out of the box",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
When running tests the this lib logs out the following constantly:

```
warn: No Sentry DSN configured, skipping initialization.
```

This makes it so the warning only outputs in produciton.