### PR TITLE
[ENGX-540] Update swagger to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@sentry/node": "^6.17.4",
     "lodash.omit": "^4.5.0",
     "openapi-typescript": "^4.4.0",
-    "swagger-ui-express": "^4.0.6"
+    "swagger-ui-express": "^4.5.0"
   },
   "standard": {
     "globals": [


### PR DESCRIPTION
https://aussiecommerce.atlassian.net/browse/ENGX-540

svc-flights-amadeus is using our own @luxuryescapes/router library that brings a transient dependency swagger-ui-dist that has a security issue.

Instead of adding a resolution we should update @luxuryescapes/router so it depends on the later version of swagger-ui-dist.