### PR TITLE
Add generate date type

### DIFF
--- a/lib/generate-server-types.js
+++ b/lib/generate-server-types.js
@@ -15,13 +15,14 @@ const generateServerTypes = async (openApiSpec) => generateTypes(openApiSpec, {
     }
 
     if ('format' in node) {
-      if (['ISO8601', 'uuid', 'url'].includes(node.format)) {
+      if (['ISO8601', 'uuid', 'url', 'salesforceId'].includes(node.format)) {
         return 'string'
-      } else if (node.format === 'dateObj') {
+      } else if (node.format === 'dateObject') {
         return 'Date'
-      } else if (node.format === 'nullableDateObj') {
+      } else if (node.format === 'dateObjectOrNull') {
         return 'Date | null'
       }
+      return node.format
     }
   }
 })

--- a/lib/generate-server-types.js
+++ b/lib/generate-server-types.js
@@ -17,8 +17,11 @@ const generateServerTypes = async (openApiSpec) => generateTypes(openApiSpec, {
     if ('format' in node) {
       if (['ISO8601', 'uuid', 'url'].includes(node.format)) {
         return 'string'
+      } else if (node.format === 'dateObj') {
+        return 'Date'
+      } else if (node.format === 'nullableDateObj') {
+        return 'Date | null'
       }
-      return node.format
     }
   }
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/router",
-  "version": "2.5.17",
+  "version": "2.5.18",
   "description": "Wrapper around express router that provides validation and documentation out of the box",
   "main": "index.js",
   "types": "index.d.ts",

--- a/test/generate-types.test.js
+++ b/test/generate-types.test.js
@@ -33,29 +33,29 @@ const stringOrNull = () =>
 const salesforceId = () =>
   s.createMatcher({
     match: (path, id) => {
-      if (id)
-        return 'should be a 18 digit salesforce id';
+      if (id) return 'should be a salesforce id'
     },
     toJSONSchema: () => {
       return {
         type: 'string',
-        format: 'salesforceId',
-      };
-    },
-  })();
+        format: 'salesforceId'
+      }
+    }
+  })()
 
 const nullableDateObj = () =>
   s.createMatcher({
     match: (path, obj) => {
-      if (!(obj === null || obj instanceof Date))
-        return 'should be a js date object or null';
+      if (!(obj === null || obj instanceof Date)) {
+        return 'should be a js date object or null'
+      }
     },
     toJSONSchema: () => {
       return {
-        format: 'dateObjectOrNull',
-      };
-    },
-  })();
+        format: 'dateObjectOrNull'
+      }
+    }
+  })()
 
 describe('generateTypes', () => {
   it('creates definitions for deep options', async () => {

--- a/test/generate-types.test.js
+++ b/test/generate-types.test.js
@@ -30,12 +30,41 @@ const stringOrNull = () =>
     }
   })()
 
+const salesforceId = () =>
+  s.createMatcher({
+    match: (path, id) => {
+      if (id)
+        return 'should be a 18 digit salesforce id';
+    },
+    toJSONSchema: () => {
+      return {
+        type: 'string',
+        format: 'salesforceId',
+      };
+    },
+  })();
+
+const nullableDateObj = () =>
+  s.createMatcher({
+    match: (path, obj) => {
+      if (!(obj === null || obj instanceof Date))
+        return 'should be a js date object or null';
+    },
+    toJSONSchema: () => {
+      return {
+        format: 'dateObjectOrNull',
+      };
+    },
+  })();
+
 describe('generateTypes', () => {
   it('creates definitions for deep options', async () => {
     const rateSchema = s('rate', s.object({
       id: s.uuid(),
+      sf_id: salesforceId(),
       comment: nullOrString(),
       description: stringOrNull(),
+      checkInDate: nullableDateObj(),
       opt: s.optional(
         s.oneOf([
           s.enum({ values: ['hotel_only', 'hotel_package'], type: 'string' }),
@@ -86,8 +115,12 @@ export interface components {
     rate: {
       /** Format: uuid */
       id: string;
+      /** Format: salesforceId */
+      sf_id: string;
       comment: null | string;
       description: null | string;
+      /** Format: dateObjectOrNull */
+      checkInDate: Date | null;
       opt?:
         | ("hotel_only" | "hotel_package")
         | ("hotel_only" | "hotel_package")[];


### PR DESCRIPTION
The is an interesting PR proposal. Unfortunately the svc-tour data import from conn-ttc has the `Date` type for a lot of date fields. I'm currently building another data sync for conn-salesforce and need to use the said import contract.
https://github.com/lux-group/svc-connection-tour-salesforce/pull/11
The correct type should be ISODate string and we intend to migrate to this.
In the meantime, I want to generate the `Date` type by the following method. Is this too hacky? Open to better suggestions.