### PR TITLE
Add missing `aud` property to `Jwt` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -155,7 +155,8 @@ declare module "@luxuryescapes/router" {
     iss: string,
     exp: number,
     sut: boolean,
-    roles: string[]
+    roles: string[],
+    aud?: string
   }
 
   interface AuthenticatedRequest<P = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = ParsedQs>


### PR DESCRIPTION
`aud` is used for the agent ID when spoofing a user's account.