### PR TITLE
Fix type generated for string with time format

### DIFF
--- a/lib/generate-server-types.js
+++ b/lib/generate-server-types.js
@@ -1,7 +1,7 @@
 const generateTypes = require('openapi-typescript').default
 
 const generateServerTypes = async (openApiSpec) => generateTypes(openApiSpec, {
-  formatter(node) {
+  formatter (node) {
     // This handles the custom NullOrString matcher that is defined in some services
     if (
       Array.isArray(node.type) &&

--- a/lib/generate-server-types.js
+++ b/lib/generate-server-types.js
@@ -1,7 +1,7 @@
 const generateTypes = require('openapi-typescript').default
 
 const generateServerTypes = async (openApiSpec) => generateTypes(openApiSpec, {
-  formatter (node) {
+  formatter(node) {
     // This handles the custom NullOrString matcher that is defined in some services
     if (
       Array.isArray(node.type) &&
@@ -15,7 +15,7 @@ const generateServerTypes = async (openApiSpec) => generateTypes(openApiSpec, {
     }
 
     if ('format' in node) {
-      if (['ISO8601', 'uuid', 'url', 'salesforceId'].includes(node.format)) {
+      if (['ISO8601', 'uuid', 'url', 'salesforceId', 'time'].includes(node.format)) {
         return 'string'
       } else if (node.format === 'dateObject') {
         return 'Date'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/router",
-  "version": "2.5.19",
+  "version": "2.5.20",
   "description": "Wrapper around express router that provides validation and documentation out of the box",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
If a custom string field matcher specifies `format: 'time'`, leave it as `string` when generating TS types.

Fixes this undesired type generation: https://github.com/lux-group/svc-trip/pull/285#issuecomment-1307891493

(I suspect what we really need is a way for services to specify how their schema fields should be translated to TS types, rather than having it centrally defined in the router package.)