### PR TITLE
Adding status field to error objects (should let Sentry handling them

### DIFF
--- a/lib/errors/HTTPError.js
+++ b/lib/errors/HTTPError.js
@@ -5,6 +5,7 @@ class HTTPError extends Error {
     this.code = code
     this.errors = errors || [message]
     this.refCode = refCode
+    this.status = code
     this.responseJson = {
       status: this.code,
       message: this.message,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/router",
-  "version": "2.5.20",
+  "version": "2.5.21",
   "description": "Wrapper around express router that provides validation and documentation out of the box",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Sentry logs all errors with 'status' fields >= 500.

Out router Errors didn't have 'status' fields.

This should fix it