### PR TITLE
using lib logger to format errors in new relic

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ const routerInstance = router(server, {
   swaggerBaseProperties, // the base properties to include in the swagger definition
   sentryDSN: 'FIND_ME_IN_SENTRY', // optional, provide if you want to auto-report unhandled exceptions to Sentry
   appEnv: process.ENV.APP_ENV, // optional, used to specify the env in Sentry, defaults to "unknown"
+  logger: logger, // pass in the luxuryescapes logger and the error handler will use this, resulting in single line log messages in new relic with stack traces.
 })
 
 // define routes

--- a/lib/middleware/error-handler.js
+++ b/lib/middleware/error-handler.js
@@ -17,6 +17,7 @@ module.exports = exports = (opts) => {
     err.http_status = err.code || 500
     err.http_method = req.method
     err.http_path = req.url
+    err.source = 'lib-router'
     if (!(err instanceof HTTPError)) {
       logger.error('Unexpected error', err) // log the original error
       err = new ServerError(err.message || 'Something went wrong')

--- a/lib/middleware/error-handler.js
+++ b/lib/middleware/error-handler.js
@@ -1,4 +1,4 @@
-const { HTTPError, ServerError } = require('../errors');
+const { HTTPError, ServerError } = require('../errors')
 
 module.exports = exports = (opts) => {
   /* this function returns the errorHandler function that is
@@ -9,18 +9,21 @@ module.exports = exports = (opts) => {
    * much nicer stack traces within new relic, if not console will be used to log
    * and this will result in multiline messages within new relic.
    */
-  const logger = opts?.logger || console;
+  let logger = console
+  if (opts && opts.logger) {
+    logger = opts.logger
+  }
   const errorHandler = (err, req, res, next) => {
-    err.http_status = err.code || 500;
-    err.http_method = req.method;
-    err.http_path = req.url;
+    err.http_status = err.code || 500
+    err.http_method = req.method
+    err.http_path = req.url
     if (!(err instanceof HTTPError)) {
-      logger.error('Unexpected error', err); // log the original error
-      err = new ServerError(err.message || 'Something went wrong');
+      logger.error('Unexpected error', err) // log the original error
+      err = new ServerError(err.message || 'Something went wrong')
     } else if (err instanceof ServerError) {
-      logger.error('Unexpected error', err); // log manually thrown server errors too!
+      logger.error('Unexpected error', err) // log manually thrown server errors too!
     }
-    res.status(err.code).json(err.responseJson);
-  };
-  return errorHandler;
-};
+    res.status(err.code).json(err.responseJson)
+  }
+  return errorHandler
+}

--- a/lib/middleware/error-handler.js
+++ b/lib/middleware/error-handler.js
@@ -1,12 +1,26 @@
-const { HTTPError, ServerError } = require('../errors')
+const { HTTPError, ServerError } = require('../errors');
 
-module.exports = exports = (err, req, res, next) => {
-  if (!(err instanceof HTTPError)) {
-    console.error('Unexpected error', err) // log the original error
-    err = new ServerError(err.message || 'Something went wrong')
-  } else if (err instanceof ServerError) {
-    console.error('Unexpected error', err) // log manually thrown server errors too!
-  }
-
-  res.status(err.code).json(err.responseJson)
-}
+module.exports = exports = (opts) => {
+  /* this function returns the errorHandler function that is
+   * used when an express app throws an unexpected error
+   * this will result in a http status code in the 500 range
+   *
+   * passing in the luxuryescapes logger into the function will result in
+   * much nicer stack traces within new relic, if not console will be used to log
+   * and this will result in multiline messages within new relic.
+   */
+  const logger = opts?.logger || console;
+  const errorHandler = (err, req, res, next) => {
+    err.http_status = err.code || 500;
+    err.http_method = req.method;
+    err.http_path = req.url;
+    if (!(err instanceof HTTPError)) {
+      logger.error('Unexpected error', err); // log the original error
+      err = new ServerError(err.message || 'Something went wrong');
+    } else if (err instanceof ServerError) {
+      logger.error('Unexpected error', err); // log manually thrown server errors too!
+    }
+    res.status(err.code).json(err.responseJson);
+  };
+  return errorHandler;
+};

--- a/lib/router.js
+++ b/lib/router.js
@@ -3,7 +3,7 @@ const swaggerUi = require('swagger-ui-express')
 
 const generateSwagger = require('./generate-swagger')
 const asyncMiddleware = require('./middleware/async')
-const errorHandler = require('./middleware/error-handler')
+const createErrorHandler = require('./middleware/error-handler')
 const networkLogger = require('./middleware/network-logger')
 const requestValidator = require('./middleware/request-validator')
 const responseValidator = require('./middleware/response-validator')
@@ -104,6 +104,7 @@ module.exports = exports = (app, opts = { }) => {
     },
     useErrorHandler: () => {
       sentry.handleErrors(app, opts)
+      const errorHandler = createErrorHandler(opts)
       app.use(errorHandler)
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/router",
-  "version": "2.5.22",
+  "version": "2.5.23",
   "description": "Wrapper around express router that provides validation and documentation out of the box",
   "main": "index.js",
   "types": "index.d.ts",

--- a/test/integration/router.test.js
+++ b/test/integration/router.test.js
@@ -1,8 +1,9 @@
 const express = require('express')
 const s = require('@luxuryescapes/strummer')
 const request = require('supertest')
+const createErrorHandler = require('../../lib/middleware/error-handler')
 
-const { router, errorHandler, errors } = require('../../index')
+const { router, errors } = require('../../index')
 const uuid = require('../../lib/utils/uuid')
 
 const swaggerBaseProperties = {
@@ -115,6 +116,7 @@ describe('router', () => {
       handlers: [echoHandler]
     })
     routerInstance.serveSwagger('/docs')
+    const errorHandler = createErrorHandler(opts)
     server.use(errorHandler)
     return new Promise((resolve) => {
       app = server.listen(resolve)


### PR DESCRIPTION
currently when a express app throws a exception within a request - response cycle the output
is logged using console, this PR enables us to use the luxuryescapes lib-logger
to log these expections.

As it stands console log will log the stack trace within new relic, but because the
stack trace is a string with many new line chars within it it appears as many log
lines in new relic, with this change it will only appear as one line which will contain
the key **stack** the value of which will be the stack trace.

I have also added the http_method, http_status (which I believe in all cases will be 500) and http_path
this will bring the log message  in line with the access log messages produced by the heroku router.

As it stand in order to get the stack trace for any 500 error code you need to find the router log, then
inspect log messages around it and decipher the single line messages that make up the stack trace, with this
everything should be on one line!

Hopefully this will make it really easy for people to see the stack trace behind every 500 error.
