### PR TITLE
ENGX-711: Add `sanitizeKeys` attribute to stop passing PI to Sentry.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ const routerInstance = router(server, {
   sentryDSN: 'FIND_ME_IN_SENTRY', // optional, provide if you want to auto-report unhandled exceptions to Sentry
   appEnv: process.ENV.APP_ENV, // optional, used to specify the env in Sentry, defaults to "unknown"
   logger: logger, // pass in the luxuryescapes logger and the error handler will use this, resulting in single line log messages in new relic with stack traces.
+  sanitizeKeys: [/_token$/, /password/i, "someHideousKey", "path.with.dot"], // array of keys or paths to sanitize from the request body, query and params on error
 })
 
 // define routes
@@ -100,7 +101,7 @@ routerInstance.put({
   summary: 'This route is about something', // for swagger
   description: 'This route does something', // for swagger
   validateResponses: false, //  false response body will not be validated against schema, true = response body validated against schema DEFAULT: false
-  warnOnRequestValidationError: false // false = throw error, true = log warning DEFAULT: false
+  warnOnRequestValidationError: false, // false = throw error, true = log warning DEFAULT: false
   logRequests: true, // true = request and response will be logged DEFAULT: false,
   correlationIdExtractor: (req, res) => { return req.params.id }, // for use when logRequests is TRUE, this will be used to extract the correlationid from the request/response for use in the log output DEFAULT: null
   logger: new Bunyan(), // you can pass in a logger that will be used for logging output , must have methods `log`, `warn` and `error` DEFAULT: console

--- a/index.d.ts
+++ b/index.d.ts
@@ -60,6 +60,7 @@ declare module "@luxuryescapes/router" {
       definitions: object;
       preHandlers?: ExpressHandler[];
     };
+    sanitizeKeys?: Array<string | RegExp>;
   }
 
   interface RouteSchema {

--- a/lib/sentry.js
+++ b/lib/sentry.js
@@ -1,4 +1,5 @@
 const errors = require('./errors')
+const sanitizeObject = require('./utils/sanitizer').sanitizeObject
 
 let Sentry
 
@@ -35,13 +36,18 @@ const initialize = (opts) => {
       dsn: opts.sentryDSN,
       environment: appEnv,
       beforeSend: (event, hint) => {
-        if (!hint) return event
-
-        // Do report manually thrown ServerErrors
-        if (hint.originalException instanceof errors.ServerError) return event
-
         // Don't report other HTTPErrors as they are expected.
-        if (hint.originalException instanceof errors.HTTPError) return null
+        if (hint && hint.originalException instanceof errors.HTTPError) return null
+
+        if (opts.sanitizeKeys) {
+          const sanitizeKeys = opts.sanitizeKeys
+          sanitizeObject(event.request.cookies, sanitizeKeys)
+          sanitizeObject(event.request.headers, sanitizeKeys)
+
+          if (event.request.data) {
+            event.request.data = JSON.stringify(sanitizeObject(JSON.parse(event.request.data), sanitizeKeys))
+          }
+        }
 
         return event
       }

--- a/lib/utils/sanitizer.js
+++ b/lib/utils/sanitizer.js
@@ -1,0 +1,100 @@
+'use strict'
+
+function sanitizeObject (obj, sanitizeKeyOrPaths) {
+  if (!obj || !sanitizeKeyOrPaths || sanitizeKeyOrPaths.length === 0) {
+    return obj
+  }
+
+  if (typeof obj === 'object') {
+    const sanitizePaths = sanitizeKeyOrPaths.filter((key) => isPath(key))
+    sanitizePath(obj, sanitizePaths)
+
+    const sanitizeKeys = sanitizeKeyOrPaths.filter((key) => !isPath(key))
+    Object.keys(obj).forEach((key) => {
+      if (matchKeys(key, sanitizeKeys)) {
+        obj[key] = maskValue(obj[key])
+      } else {
+        sanitizeObject(obj[key], sanitizeKeys)
+      }
+    })
+  }
+  return obj
+}
+
+function isPath (key) {
+  return typeof key === 'string' && key.indexOf('.') !== -1
+}
+
+function sanitizePath (obj, paths) {
+  paths.forEach((path) => {
+    const pathParts = path.split('.')
+    if (hasPath(obj, pathParts)) {
+      maskPath(obj, pathParts)
+    }
+  })
+}
+
+function hasPath (obj, pathParts) {
+  let current = obj
+  for (let i = 0; i < pathParts.length; i++) {
+    if (!current[pathParts[i]]) {
+      return false
+    }
+    current = current[pathParts[i]]
+  }
+  return true
+}
+
+function maskPath (obj, pathParts) {
+  let current = obj
+  for (let i = 0; i < pathParts.length; i++) {
+    if (i === pathParts.length - 1) {
+      current[pathParts[i]] = maskValue(current[pathParts[i]])
+    } else {
+      current = current[pathParts[i]]
+    }
+  }
+}
+
+function matchKeys (key, sanitizeKeys) {
+  return sanitizeKeys.some((sanitizeKey) => {
+    if (typeof sanitizeKey === 'string') {
+      return sanitizeKey === key
+    } else if (sanitizeKey instanceof RegExp) {
+      return sanitizeKey.test(key)
+    }
+  })
+}
+
+function maskValue (value) {
+  if (!value) {
+    return value
+  }
+
+  if (typeof value === 'string') {
+    return '********'
+  }
+  if (Array.isArray(value)) {
+    return maskArray(value)
+  }
+  if (typeof value === 'object') {
+    maskObject(value)
+  }
+  return value
+}
+
+function maskArray (obj) {
+  return obj.map((item) => {
+    return maskValue(item)
+  })
+}
+
+function maskObject (obj) {
+  Object.keys(obj).forEach((key) => {
+    obj[key] = maskValue(obj[key])
+  })
+}
+
+module.exports = {
+  sanitizeObject: sanitizeObject
+}

--- a/lib/utils/sanitizer.spec.js
+++ b/lib/utils/sanitizer.spec.js
@@ -1,0 +1,87 @@
+const { sanitizeObject } = require('./sanitizer')
+
+describe('sanitizeObject function', () => {
+  const event = {
+    request: {
+      cookies: {
+        name: 'John Doe',
+        email: 'johndoe@example.com',
+        password: 'password123'
+      },
+      data: {
+        id: 1,
+        name: 'Product',
+        price: 9.99,
+        travellers: [
+          {
+            name: 'John Doe',
+            email: 'john.doe@test.com',
+            title: null
+          },
+          {
+            name: 'Jane Doe',
+            email: 'jane.doe@test.com',
+            title: null
+          }
+        ],
+        user: {
+          email: 'user@test.com'
+        }
+      },
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer token123'
+      }
+    }
+  }
+  const sanitizeKeys = [/^password$/, 'Authorization', 'travellers', 'user.email']
+
+  it('should sanitize keys in request.cookies', () => {
+    sanitizeObject(event.request.cookies, sanitizeKeys)
+    expect(event.request.cookies).toEqual({
+      name: 'John Doe',
+      email: 'johndoe@example.com',
+      password: '********'
+    })
+  })
+
+  it('should sanitize keys in request.data', () => {
+    sanitizeObject(event.request.data, sanitizeKeys)
+    expect(event.request.data).toEqual({
+      id: 1,
+      name: 'Product',
+      price: 9.99,
+      travellers: [
+        {
+          name: '********',
+          email: '********',
+          title: null
+        },
+        {
+          name: '********',
+          email: '********',
+          title: null
+        }
+      ],
+      user: {
+        email: '********'
+      }
+    })
+  })
+
+  it('should sanitize keys in request.headers', () => {
+    sanitizeObject(event.request.headers, sanitizeKeys)
+    expect(event.request.headers).toEqual({
+      'Content-Type': 'application/json',
+      Authorization: '********'
+    })
+  })
+
+  it('should do nothing if sanitizeKeys is empty', () => {
+    sanitizeObject(event)
+    expect(event.request).toEqual(event.request)
+
+    sanitizeObject(event, [])
+    expect(event.request).toEqual(event.request)
+  })
+})


### PR DESCRIPTION
This PR allows us to scrub sensitive personal information on Sentry error logging.

Before:
https://luxury-escapes-9m.sentry.io/issues/3955688380/events/6f9c45b6e01f4f4f8a70ac98a5f00af5/?project=4504138441818112

You can see the body contains the traveller's name:
<img width="357" alt="image" src="https://user-images.githubusercontent.com/13145171/222628401-6e8fb9fa-ae0a-4a79-8684-2918baeb4057.png">

After:
With the following settings:
<img width="348" alt="image" src="https://user-images.githubusercontent.com/13145171/222628568-f07026ff-f66e-43d6-8c6d-19991c14b801.png">

https://luxury-escapes-9m.sentry.io/issues/3955688380/events/1feb397b336246728a80bdfbecd9df1e/?project=4504138441818112

You can see the traveller's name is hidden with ***
<img width="349" alt="image" src="https://user-images.githubusercontent.com/13145171/222628731-a28cbae2-a266-425c-8d26-70d4a3ab511f.png">
