### PR TITLE
change middleware to named functions

### DIFF
--- a/lib/middleware/async.js
+++ b/lib/middleware/async.js
@@ -1,5 +1,5 @@
 module.exports = exports = fn => {
-  return function asyncMiddleware(req, res, next) {
+  return function asyncMiddleware (req, res, next) {
     Promise.resolve(fn(req, res, next)).catch(next)
   }
 }

--- a/lib/middleware/async.js
+++ b/lib/middleware/async.js
@@ -1,5 +1,5 @@
 module.exports = exports = fn => {
-  return (req, res, next) => {
+  return function asyncMiddleware(req, res, next) {
     Promise.resolve(fn(req, res, next)).catch(next)
   }
 }

--- a/lib/middleware/error-handler.js
+++ b/lib/middleware/error-handler.js
@@ -13,7 +13,7 @@ module.exports = exports = (opts) => {
   if (opts && opts.logger) {
     logger = opts.logger
   }
-  function errorHandlerMiddlware(err, req, res, next) {
+  return function errorHandlerMiddlware (err, req, res, next) {
     err.http_status = err.code || 500
     err.http_method = req.method
     err.http_path = req.url
@@ -26,5 +26,4 @@ module.exports = exports = (opts) => {
     }
     res.status(err.code).json(err.responseJson)
   }
-  return errorHandlerMiddlware
 }

--- a/lib/middleware/error-handler.js
+++ b/lib/middleware/error-handler.js
@@ -13,7 +13,7 @@ module.exports = exports = (opts) => {
   if (opts && opts.logger) {
     logger = opts.logger
   }
-  const errorHandler = (err, req, res, next) => {
+  function errorHandlerMiddlware(err, req, res, next) {
     err.http_status = err.code || 500
     err.http_method = req.method
     err.http_path = req.url
@@ -26,5 +26,5 @@ module.exports = exports = (opts) => {
     }
     res.status(err.code).json(err.responseJson)
   }
-  return errorHandler
+  return errorHandlerMiddlware
 }

--- a/lib/middleware/network-logger.js
+++ b/lib/middleware/network-logger.js
@@ -1,7 +1,7 @@
 const uuid = require('../utils/uuid')
 
 module.exports = exports = ({ correlationIdExtractor, logger = console, shouldLogResponses = true }) => {
-  return async function networkLoggerMiddleware(req, res, next) {
+  return async function networkLoggerMiddleware (req, res, next) {
     const correlationId = correlationIdExtractor ? correlationIdExtractor(req, res) : uuid.get()
     logger.info(`request: (${correlationId}) ${req.method} ${req.url} ${req.body ? JSON.stringify(req.body) : ''}`)
     const originalFunc = res.json

--- a/lib/middleware/network-logger.js
+++ b/lib/middleware/network-logger.js
@@ -1,7 +1,7 @@
 const uuid = require('../utils/uuid')
 
 module.exports = exports = ({ correlationIdExtractor, logger = console, shouldLogResponses = true }) => {
-  return async (req, res, next) => {
+  return async function networkLoggerMiddleware(req, res, next) {
     const correlationId = correlationIdExtractor ? correlationIdExtractor(req, res) : uuid.get()
     logger.info(`request: (${correlationId}) ${req.method} ${req.url} ${req.body ? JSON.stringify(req.body) : ''}`)
     const originalFunc = res.json

--- a/lib/middleware/request-validator.js
+++ b/lib/middleware/request-validator.js
@@ -1,7 +1,7 @@
 const { InvalidRequestError } = require('../errors')
 
 module.exports = ({ logger = console, schema, warnOnRequestValidationError }) => {
-  return (req, res, next) => {
+  return function requestValidatorMiddleware(req, res, next) {
     if (schema.params) {
       let errors = schema.params.match(req.params)
 

--- a/lib/middleware/request-validator.js
+++ b/lib/middleware/request-validator.js
@@ -1,7 +1,7 @@
 const { InvalidRequestError } = require('../errors')
 
 module.exports = ({ logger = console, schema, warnOnRequestValidationError }) => {
-  return function requestValidatorMiddleware(req, res, next) {
+  return function requestValidatorMiddleware (req, res, next) {
     if (schema.params) {
       let errors = schema.params.match(req.params)
 

--- a/lib/middleware/response-validator.js
+++ b/lib/middleware/response-validator.js
@@ -1,7 +1,7 @@
 const { ServerError } = require('../errors')
 
 module.exports = exports = ({ schema }) => {
-  return function responseValidatorMiddleware(req, res, next) {
+  return function responseValidatorMiddleware (req, res, next) {
     const originalFunc = res.json
     res.json = (responseBody) => {
       if (schema[res.statusCode]) {

--- a/lib/middleware/response-validator.js
+++ b/lib/middleware/response-validator.js
@@ -1,7 +1,7 @@
 const { ServerError } = require('../errors')
 
 module.exports = exports = ({ schema }) => {
-  return (req, res, next) => {
+  return function responseValidatorMiddleware(req, res, next) {
     const originalFunc = res.json
     res.json = (responseBody) => {
       if (schema[res.statusCode]) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/router",
-  "version": "2.5.24",
+  "version": "2.5.25",
   "description": "Wrapper around express router that provides validation and documentation out of the box",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Change middleware to named functions.

This is so Spans in newrelic can be named correctly rather than being called annoymous.
![image](https://user-images.githubusercontent.com/96396387/225802837-9b7dcac2-3c19-4872-82af-f65fb67fd045.png)
