### PR TITLE
Add stack to response json

### DIFF
--- a/lib/errors/HTTPError.js
+++ b/lib/errors/HTTPError.js
@@ -10,8 +10,10 @@ class HTTPError extends Error {
       status: this.code,
       message: this.message,
       errors: this.errors,
-      ref_code: this.refCode
+      ref_code: this.refCode,
+      stack: this.stack
     }
+    console.log('logging this: ', this)
   }
 }
 

--- a/lib/errors/HTTPError.js
+++ b/lib/errors/HTTPError.js
@@ -13,7 +13,6 @@ class HTTPError extends Error {
       ref_code: this.refCode,
       stack: this.stack
     }
-    console.log('logging this: ', this)
   }
 }
 

--- a/test/integration/router.test.js
+++ b/test/integration/router.test.js
@@ -285,6 +285,7 @@ describe('router', () => {
         expect(response.body).toEqual({
           status: 400,
           message: 'Invalid url query parameters',
+          stack: expect.any(String),
           errors: [
             {
               path: 'hello',
@@ -292,6 +293,8 @@ describe('router', () => {
             }
           ]
         })
+        expect(response.body.stack).toMatch(`Error: Invalid url query parameters
+    at new InvalidRequestError`);
       })
 
       it('should error if params are invalid', async () => {
@@ -303,9 +306,10 @@ describe('router', () => {
           })
 
         expect(response.status).toEqual(400)
-        expect(response.body).toEqual({
+        expect(response.body).toEqual(expect.objectContaining({
           status: 400,
           message: 'Invalid url path parameters',
+          stack: expect.any(String),
           errors: [
             {
               path: 'id',
@@ -313,7 +317,9 @@ describe('router', () => {
               value: 'myid123'
             }
           ]
-        })
+        }))
+        expect(response.body.stack).toMatch(`Error: Invalid url path parameters
+    at new InvalidRequestError`);
       })
 
       it('should error if payload is invalid', async () => {
@@ -325,9 +331,10 @@ describe('router', () => {
           })
 
         expect(response.status).toEqual(400)
-        expect(response.body).toEqual({
+        expect(response.body).toEqual(expect.objectContaining({
           status: 400,
           message: 'Invalid payload',
+          stack: expect.any(String),
           errors: [
             {
               path: 'action',
@@ -335,7 +342,9 @@ describe('router', () => {
               value: 'delete'
             }
           ]
-        })
+        }))
+        expect(response.body.stack).toMatch(`Error: Invalid payload
+    at new InvalidRequestError`);
       })
     })
 
@@ -418,6 +427,7 @@ describe('router', () => {
         expect(response.body).toEqual({
           status: 500,
           message: 'Response body does not match the specified schema',
+          stack: expect.any(String),
           errors: [
             {
               path: 'extraField',
@@ -541,16 +551,19 @@ describe('router', () => {
         })
 
       expect(response.status).toEqual(422)
-      expect(response.body).toEqual({
+      expect(response.body).toEqual(expect.objectContaining({
         status: 422,
         message: 'Unprocessable yo',
+        stack: expect.any(String),
         errors: [
           {
             path: 'something',
             message: 'hahahehe'
           }
         ]
-      })
+      }))
+      expect(response.body.stack).toMatch(`Error: Unprocessable yo
+    at new UnprocessableEntityError`);
     })
 
     it('should coerce unknown errors to a 500', async () => {
@@ -562,11 +575,16 @@ describe('router', () => {
         })
 
       expect(response.status).toEqual(500)
-      expect(response.body).toEqual({
+      expect(response.body).toEqual(expect.objectContaining({
         status: 500,
         message: 'Unknown error',
         errors: ['Unknown error']
-      })
+      }));
+
+      expect(response.body.stack).toMatch(`Error: Unknown error
+    at new ServerError`);
+
+    
     })
   })
 })

--- a/test/integration/router.test.js
+++ b/test/integration/router.test.js
@@ -294,7 +294,7 @@ describe('router', () => {
           ]
         })
         expect(response.body.stack).toMatch(`Error: Invalid url query parameters
-    at new InvalidRequestError`);
+    at new InvalidRequestError`)
       })
 
       it('should error if params are invalid', async () => {
@@ -319,7 +319,7 @@ describe('router', () => {
           ]
         }))
         expect(response.body.stack).toMatch(`Error: Invalid url path parameters
-    at new InvalidRequestError`);
+    at new InvalidRequestError`)
       })
 
       it('should error if payload is invalid', async () => {
@@ -344,7 +344,7 @@ describe('router', () => {
           ]
         }))
         expect(response.body.stack).toMatch(`Error: Invalid payload
-    at new InvalidRequestError`);
+    at new InvalidRequestError`)
       })
     })
 
@@ -563,7 +563,7 @@ describe('router', () => {
         ]
       }))
       expect(response.body.stack).toMatch(`Error: Unprocessable yo
-    at new UnprocessableEntityError`);
+    at new UnprocessableEntityError`)
     })
 
     it('should coerce unknown errors to a 500', async () => {
@@ -579,12 +579,10 @@ describe('router', () => {
         status: 500,
         message: 'Unknown error',
         errors: ['Unknown error']
-      }));
+      }))
 
       expect(response.body.stack).toMatch(`Error: Unknown error
-    at new ServerError`);
-
-    
+    at new ServerError`)
     })
   })
 })


### PR DESCRIPTION
Our current distributed tracing does not display the stack trace. We want to include stack in the json response

![image](https://github.com/lux-group/router/assets/106052720/24a757d6-06c6-4f68-a120-ce0dd0e860d9)
