### PR TITLE
NOJIRA: Fix logging information missing

### DIFF
--- a/lib/middleware/request-validator.js
+++ b/lib/middleware/request-validator.js
@@ -7,7 +7,7 @@ module.exports = ({ logger = console, schema, warnOnRequestValidationError }) =>
 
       if (errors.length) {
         if (warnOnRequestValidationError) {
-          logger.warn('[VALIDATION WARNING] Invalid url path parameters', JSON.stringify(errors))
+          logger.warn(`[VALIDATION WARNING] Invalid url path parameters: ${JSON.stringify(errors)}`)
         } else {
           throw new InvalidRequestError('Invalid url path parameters', errors)
         }
@@ -17,7 +17,7 @@ module.exports = ({ logger = console, schema, warnOnRequestValidationError }) =>
       let errors = schema.query.match(req.query)
       if (errors.length) {
         if (warnOnRequestValidationError) {
-          logger.warn('[VALIDATION WARNING] Invalid url query parameters', JSON.stringify(errors))
+          logger.warn(`[VALIDATION WARNING] Invalid url query parameters: ${JSON.stringify(errors)}`)
         } else {
           throw new InvalidRequestError('Invalid url query parameters', errors)
         }
@@ -27,7 +27,7 @@ module.exports = ({ logger = console, schema, warnOnRequestValidationError }) =>
       let errors = schema.body.match(req.body)
       if (errors.length) {
         if (warnOnRequestValidationError) {
-          logger.warn('[VALIDATION WARNING] Invalid payload', JSON.stringify(errors))
+          logger.warn(`[VALIDATION WARNING] Invalid payload: ${JSON.stringify(errors)}`)
         } else {
           throw new InvalidRequestError('Invalid payload', errors)
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/router",
-  "version": "2.5.25",
+  "version": "2.5.26",
   "description": "Wrapper around express router that provides validation and documentation out of the box",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
This PR fixes the issue that sometime the logging would miss the data.

As the project may use Winston as the logger, which does not support logging a string message from the second parameter, which is expected to be an object. So the logging as follows does not include the details in the log message:

`logger.warn('[VALIDATION WARNING] Invalid payload', JSON.stringify(errors))`

Output:
`{"label":"test","level":"warn","message":"[VALIDATION WARNING] Invalid payload","service":"test-le-svc-cart"}`

New Relic:
<img width="469" alt="image" src="https://github.com/lux-group/router/assets/13145171/e3bd49f6-1af3-4f66-9513-d3fbeddc7e17">

After the fixing:
Output:
<img width="940" alt="image" src="https://github.com/lux-group/router/assets/13145171/67f48ed6-cd62-431c-b1cb-2b82f0af76ce">



