### PR TITLE
Add tsdoc comments to `RouteOptions`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -73,16 +73,39 @@ declare module "@luxuryescapes/router" {
   }
 
   interface RouteOptions {
+    /**
+     * Path for the route
+     * @see https://expressjs.com/en/4x/api.html#path-examples
+     */
     url: string;
+    /** The route will be referenced by this ID in the contract */
     operationId?: string;
+    /** Request and response schemas. The endpoint will use these to validate incoming requests and outgoing responses. */
     schema?: RouteSchema;
+    /**
+     * If `false`, the Swagger docs will specify that a cookie containing an access token is required.
+     * @defaultValue `false`
+     */
     isPublic?: boolean;
+    /** Pre-handlers are run before request validation. Usually used for authentication. */
     preHandlers?: ExpressHandler[];
+    /** Handlers are run after request validation. */
     handlers: ((req: any, res: Response, next: NextFunction) => void)[]
+    /** For Swagger docs */
     tags?: string[];
+    /** For Swagger docs */
     summary?: string;
+    /** For Swagger docs */
     description?: string;
+    /**
+     * If `true`, logs a warning on request validation error.
+     * @defaultValue `false`
+     */
     warnOnRequestValidationError?: boolean;
+    /**
+     * Options to be passed to `express.json()`
+     * @defaultValue `{}`
+     */
     jsonOptions?: { [option: string]: string | number | boolean | null | undefined };
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -104,6 +104,7 @@ declare module "@luxuryescapes/router" {
     warnOnRequestValidationError?: boolean;
     /**
      * Options to be passed to `express.json()`
+     * @see https://expressjs.com/en/4x/api.html#express.json
      * @defaultValue `{}`
      */
     jsonOptions?: { [option: string]: string | number | boolean | null | undefined };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/router",
-  "version": "2.5.26",
+  "version": "2.5.27",
   "description": "Wrapper around express router that provides validation and documentation out of the box",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
It's not always clear what the various route options mean. This PR adds some tsdoc comments to make it easier to find out.

![image](https://github.com/lux-group/router/assets/20634762/06b9316f-a636-4836-b9fd-f32b7fae56c3)
