### PR TITLE
fix middleware names in spans

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -43,9 +43,15 @@ const handle = (
     _handlers.push(responseValidator({ schema: schema.responses }))
   }
 
-  _handlers = [..._handlers, ...handlers].map(handler =>
-    asyncMiddleware(handler)
-  )
+  _handlers = [..._handlers, ...handlers].map(handler => {
+    const wrappedHandler = asyncMiddleware(handler)
+    // this ensures that the original middleware name is preserved and not rewritten to 'asyncMiddleware'
+    Object.defineProperty(wrappedHandler, 'name', {
+      writable: false,
+      value: handler.name
+    })
+    return wrappedHandler
+  })
   app[method](url, _handlers)
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/router",
-  "version": "2.5.28",
+  "version": "2.5.29",
   "description": "Wrapper around express router that provides validation and documentation out of the box",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Currently, all middleware is labelled as `asyncMiddleware`. See screenshot below.

This PR rewrites the wrappedMiddleware back to the original middleware name to enable better performance tracing.

**Before**
![image](https://github.com/lux-group/router/assets/96396387/5962d121-a78b-4f66-ba68-9eb8359ebca3)

**After**
![image](https://github.com/lux-group/router/assets/96396387/ff2491b3-6192-41af-adf4-bce0a75051a7)

