### PR TITLE
Add type user object to authenticated requests

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -200,6 +200,7 @@ declare module "@luxuryescapes/router" {
       jwt: Jwt;
       user: { // verifyUserSignature only sets jwt, but most auth checks use verifyUser which sets the user object as well.
         id_member: string
+        roles: string[]
       }
     }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -198,7 +198,7 @@ declare module "@luxuryescapes/router" {
   interface AuthenticatedRequest<P = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = ParsedQs>
     extends ExpressRequest<P, ResBody, ReqBody, ReqQuery> {
       jwt: Jwt;
-      user: { // verifyUserSignature only sets jwt, but most cases we check verifyUser which sets the user.
+      user: { // verifyUserSignature only sets jwt, but most auth checks use verifyUser which sets the user object as well.
         id_member: string
       }
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -198,7 +198,9 @@ declare module "@luxuryescapes/router" {
   interface AuthenticatedRequest<P = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = ParsedQs>
     extends ExpressRequest<P, ResBody, ReqBody, ReqQuery> {
       jwt: Jwt;
-      user?: unknown; // optional because verifyUserSignature only sets jwt
+      user: { // verifyUserSignature only sets jwt, but most cases we check verifyUser which sets the user.
+        id_member: string
+      }
     }
 
   export interface Handler<

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,7 @@ declare module "@luxuryescapes/router" {
   import { Matcher } from "@luxuryescapes/strummer"
   import { ParamsDictionary, RequestHandler as ExpressHandler } from 'express-serve-static-core';
   import { ParsedQs } from "qs";
+  import { API } from "@luxuryescapes/lib-types";
 
   export function errorHandler(
     err: Error,
@@ -199,8 +200,8 @@ declare module "@luxuryescapes/router" {
     extends ExpressRequest<P, ResBody, ReqBody, ReqQuery> {
       jwt: Jwt;
       user: { // verifyUserSignature only sets jwt, but most auth checks use verifyUser which sets the user object as well.
-        id_member: string
-        roles: string[]
+        id_member: API.Auth.User['id_member']
+        roles: API.Auth.User['roles']
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -63,6 +63,5 @@
   },
   "engines": {
     "node": ">=14.17.0"
-  },
-  "packageManager": "yarn@1.22.19+sha1.4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "express": "^4.17.1"
   },
   "dependencies": {
+    "@luxuryescapes/lib-types": "^1.16.15",
     "@luxuryescapes/strummer": "^2.11.3",
     "@sentry/node": "^6.17.4",
     "lodash.omit": "^4.5.0",
@@ -62,5 +63,6 @@
   },
   "engines": {
     "node": ">=14.17.0"
-  }
+  },
+  "packageManager": "yarn@1.22.19+sha1.4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/router",
-  "version": "2.5.31",
+  "version": "2.5.32",
   "description": "Wrapper around express router that provides validation and documentation out of the box",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
The current types are setup for compatibility with verifyUserSignature. For most use cases outside of auth, we use the verifyUser middleware which sets the user object as well. This PR updates the types and allows us to easily use the user object from the controller without have to manually override the types.

Before:
![Screenshot 2024-10-21 at 3 14 56 pm](https://github.com/user-attachments/assets/f44731dc-f463-4901-b82f-f4db5c104e73)

Now:
![Screenshot 2024-10-21 at 3 20 31 pm](https://github.com/user-attachments/assets/69761d54-c6cb-4847-8422-68faa0e21b55)