### PR TITLE
change reference in response schema

### DIFF
--- a/lib/generate-swagger.js
+++ b/lib/generate-swagger.js
@@ -136,7 +136,7 @@ const generateResponseDefinitions = (schema, definitions) => {
         content: {
           'application/json': {
             schema: {
-              $ref: `#/definitions/${name}`
+              $ref: `#/components/schemas/${name}`
             }
           }
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/router",
-  "version": "2.5.32",
+  "version": "2.5.33",
   "description": "Wrapper around express router that provides validation and documentation out of the box",
   "main": "index.js",
   "types": "index.d.ts",

--- a/test/generate-swagger.test.js
+++ b/test/generate-swagger.test.js
@@ -299,7 +299,7 @@ describe('generateSwagger', () => {
     })
 
     expect(swagger.paths['/']['get']['responses']['200']['content']['application/json']).toEqual({
-      'schema': { '$ref': '#/definitions/rate' }
+      'schema': { '$ref': '#/components/schemas/rate' }
     })
   })
 

--- a/test/generate-types.test.js
+++ b/test/generate-types.test.js
@@ -143,7 +143,7 @@ export interface operations {
       /** 200 response */
       200: {
         content: {
-          "application/json": definitions["rate"];
+          "application/json": components["schemas"]["rate"];
         };
       };
     };


### PR DESCRIPTION
In this [PR](https://github.com/lux-group/router/commit/6870ec68e26e310acc75f8b4aa61847def986be7#diff-87e0aedba7aecf461aae9e96921bf7242139b85bde583d84ac62563bbd3bc132) it looks like the way we reference common definitions was changed when upgrading to openspec v3, but looks like one was missed

This ends up with an error when trying to generate types for your api when using a reusable component

<img width="589" alt="image" src="https://github.com/user-attachments/assets/fa817d6c-256a-41f9-9d83-e23821af7e3d">
