### PR TITLE
fix: handler body should allow any string field, not just payload

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -214,7 +214,7 @@ declare module "@luxuryescapes/router" {
       ? parameters["path"]
       : {},
     ReqBody = parameters extends { body: { [k: string]: any } }
-      ? parameters["body"][string]
+      ? parameters["body"][keyof parameters["body"]]
       : {},
     Query = parameters extends { query: any }
       ? parameters["query"]

--- a/index.d.ts
+++ b/index.d.ts
@@ -213,8 +213,8 @@ declare module "@luxuryescapes/router" {
     PathParams = parameters extends { path: any }
       ? parameters["path"]
       : {},
-    ReqBody = parameters extends { body: { payload: any } }
-      ? parameters["body"]["payload"]
+    ReqBody = parameters extends { body: { [k: string]: any } }
+      ? parameters["body"][string]
       : {},
     Query = parameters extends { query: any }
       ? parameters["query"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/router",
-  "version": "2.5.33",
+  "version": "2.5.34",
   "description": "Wrapper around express router that provides validation and documentation out of the box",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
When using named strummer matcher, we can generate contract where the body's field is not  payload, but instead use the strummer matcher name:

![image](https://github.com/user-attachments/assets/05149d15-47e2-49d7-aea0-a156a2c06507)

This PR changes the type definition to allow `req.body` to have the correct typing instead of {} in this case.